### PR TITLE
RFC 378 made it into rust nightly. Added semicolons for macro invocations

### DIFF
--- a/macros/lib.rs
+++ b/macros/lib.rs
@@ -309,7 +309,7 @@ macro_rules! content_type(
 			vec!( $( (std::str::FromStr::from_str($param).unwrap(), std::str::FromStr::from_str($value).unwrap()) ),+ )
 		)
 	});
-)
+);
 
 
 /**
@@ -346,4 +346,4 @@ macro_rules! try_send(
 			}
 		}
 	)
-)
+);


### PR DESCRIPTION
'Parse macro invocations with parentheses or square brackets as expressions no matter the context, and require curly braces or a semicolon following the invocation to invoke a macro as a statement.'
