### PR TITLE
Implement shared plugin storage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ path = "src/lib.rs"
 hyper = "*"
 time = "*"
 url = "*"
+anymap = "*"
 
 [dev-dependencies]
 tempdir = "*"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@
 extern crate url;
 extern crate time;
 extern crate hyper;
+extern crate anymap;
 
 pub use hyper::mime;
 pub use hyper::method::Method;

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -14,7 +14,9 @@ use response::{ResponseData, IntoResponseData};
 
 ///Contextual tools for plugins.
 pub struct PluginContext<'a> {
-    ///Shared storage for plugins. Local to the current request.
+    ///Shared storage for plugins. It is local to the current request and
+    ///accessible from the handler and all of the plugins. It can be used to
+    ///send data between these units.
     pub storage: &'a mut AnyMap,
 
     ///Log for notes, errors and warnings.
@@ -24,22 +26,17 @@ pub struct PluginContext<'a> {
 ///A trait for context plugins.
 ///
 ///They are able to modify and react to a `Context` before it's sent to the handler.
-#[unstable = "plugin context is not finalized"]
 pub trait ContextPlugin {
-    ///Try to modify the `Context`.
-    #[unstable = "plugin context is not finalized"]
+    ///Try to modify the handler `Context`.
     fn modify(&self, context: PluginContext, request_context: &mut Context) -> ContextAction;
 }
 
 ///The result from a context plugin.
-#[unstable = "plugin context is not finalized"]
 pub enum ContextAction {
     ///Continue to the next plugin in the stack.
-    #[unstable = "plugin context is not finalized"]
     Continue,
 
     ///Abort and send HTTP status.
-    #[unstable = "plugin context is not finalized"]
     Abort(StatusCode)
 }
 
@@ -47,51 +44,39 @@ pub enum ContextAction {
 ///A trait for response plugins.
 ///
 ///They are able to modify headers and data before it gets written in the response.
-#[unstable = "plugin context is not finalized"]
 pub trait ResponsePlugin {
     ///Set or modify headers before they are sent to the client and maybe initiate the body.
-    #[unstable = "plugin context is not finalized"]
     fn begin(&self, context: PluginContext, status: StatusCode, headers: Headers) ->
         (StatusCode, Headers, ResponseAction);
 
     ///Handle content before writing it to the body.
-    #[unstable = "plugin context is not finalized"]
     fn write<'a>(&'a self, context: PluginContext, content: Option<ResponseData<'a>>) -> ResponseAction;
 
     ///End of body writing. Last chance to add content.
-    #[unstable = "plugin context is not finalized"]
     fn end(&self, context: PluginContext) -> ResponseAction;
 }
 
 ///The result from a `ResponsePlugin`.
-#[unstable = "plugin context is not finalized"]
 pub enum ResponseAction<'a> {
     ///Continue to the next plugin and maybe write data.
-    #[unstable = "plugin context is not finalized"]
     Write(Option<ResponseData<'a>>),
 
     ///Do not continue to the next plugin.
-    #[unstable = "plugin context is not finalized"]
     DoNothing,
 
     ///Abort with an error.
-    #[unstable = "plugin context is not finalized"]
     Error(String)
 }
 
-#[unstable = "plugin context is not finalized"]
 impl<'a> ResponseAction<'a> {
-    #[unstable = "plugin context is not finalized"]
     pub fn write<T: IntoResponseData<'a>>(data: Option<T>) -> ResponseAction<'a> {
         ResponseAction::Write(data.map(|d| d.into_response_data()))
     }
 
-    #[unstable = "plugin context is not finalized"]
     pub fn do_nothing() -> ResponseAction<'static> {
         ResponseAction::DoNothing
     }
 
-    #[unstable = "plugin context is not finalized"]
     pub fn error(message: String) -> ResponseAction<'static> {
         ResponseAction::Error(message)
     }

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -2,6 +2,8 @@
 
 #![stable]
 
+use anymap::AnyMap;
+
 use StatusCode;
 use header::Headers;
 
@@ -10,25 +12,34 @@ use log::Log;
 
 use response::{ResponseData, IntoResponseData};
 
+///Contextual tools for plugins.
+pub struct PluginContext<'a> {
+    ///Shared storage for plugins. Local to the current request.
+    pub storage: &'a mut AnyMap,
+
+    ///Log for notes, errors and warnings.
+    pub log: &'a Log
+}
+
 ///A trait for context plugins.
 ///
 ///They are able to modify and react to a `Context` before it's sent to the handler.
-#[unstable = "plugin methods and parameters will change when a shared context is added"]
+#[unstable = "plugin context is not finalized"]
 pub trait ContextPlugin {
     ///Try to modify the `Context`.
-    #[unstable = "plugin methods and parameters will change when a shared context is added"]
-    fn modify(&self, log: &Log, context: &mut Context) -> ContextAction;
+    #[unstable = "plugin context is not finalized"]
+    fn modify(&self, context: PluginContext, request_context: &mut Context) -> ContextAction;
 }
 
 ///The result from a context plugin.
-#[unstable = "plugin methods and parameters will change when a shared context is added"]
+#[unstable = "plugin context is not finalized"]
 pub enum ContextAction {
     ///Continue to the next plugin in the stack.
-    #[unstable = "plugin methods and parameters will change when a shared context is added"]
+    #[unstable = "plugin context is not finalized"]
     Continue,
 
     ///Abort and send HTTP status.
-    #[unstable = "plugin methods and parameters will change when a shared context is added"]
+    #[unstable = "plugin context is not finalized"]
     Abort(StatusCode)
 }
 
@@ -36,51 +47,51 @@ pub enum ContextAction {
 ///A trait for response plugins.
 ///
 ///They are able to modify headers and data before it gets written in the response.
-#[unstable = "plugin methods and parameters will change when a shared context is added"]
+#[unstable = "plugin context is not finalized"]
 pub trait ResponsePlugin {
     ///Set or modify headers before they are sent to the client and maybe initiate the body.
-    #[unstable = "plugin methods and parameters will change when a shared context is added"]
-    fn begin(&self, log: &Log, status: StatusCode, headers: Headers) ->
+    #[unstable = "plugin context is not finalized"]
+    fn begin(&self, context: PluginContext, status: StatusCode, headers: Headers) ->
         (StatusCode, Headers, ResponseAction);
 
     ///Handle content before writing it to the body.
-    #[unstable = "plugin methods and parameters will change when a shared context is added"]
-    fn write<'a>(&'a self, log: &Log, content: Option<ResponseData<'a>>) -> ResponseAction;
+    #[unstable = "plugin context is not finalized"]
+    fn write<'a>(&'a self, context: PluginContext, content: Option<ResponseData<'a>>) -> ResponseAction;
 
     ///End of body writing. Last chance to add content.
-    #[unstable = "plugin methods and parameters will change when a shared context is added"]
-    fn end(&self, log: &Log) -> ResponseAction;
+    #[unstable = "plugin context is not finalized"]
+    fn end(&self, context: PluginContext) -> ResponseAction;
 }
 
 ///The result from a `ResponsePlugin`.
-#[unstable = "plugin methods and parameters will change when a shared context is added"]
+#[unstable = "plugin context is not finalized"]
 pub enum ResponseAction<'a> {
     ///Continue to the next plugin and maybe write data.
-    #[unstable = "plugin methods and parameters will change when a shared context is added"]
+    #[unstable = "plugin context is not finalized"]
     Write(Option<ResponseData<'a>>),
 
     ///Do not continue to the next plugin.
-    #[unstable = "plugin methods and parameters will change when a shared context is added"]
+    #[unstable = "plugin context is not finalized"]
     DoNothing,
 
     ///Abort with an error.
-    #[unstable = "plugin methods and parameters will change when a shared context is added"]
+    #[unstable = "plugin context is not finalized"]
     Error(String)
 }
 
-#[unstable = "plugin methods and parameters will change when a shared context is added"]
+#[unstable = "plugin context is not finalized"]
 impl<'a> ResponseAction<'a> {
-    #[unstable = "plugin methods and parameters will change when a shared context is added"]
+    #[unstable = "plugin context is not finalized"]
     pub fn write<T: IntoResponseData<'a>>(data: Option<T>) -> ResponseAction<'a> {
         ResponseAction::Write(data.map(|d| d.into_response_data()))
     }
 
-    #[unstable = "plugin methods and parameters will change when a shared context is added"]
+    #[unstable = "plugin context is not finalized"]
     pub fn do_nothing() -> ResponseAction<'static> {
         ResponseAction::DoNothing
     }
 
-    #[unstable = "plugin methods and parameters will change when a shared context is added"]
+    #[unstable = "plugin context is not finalized"]
     pub fn error(message: String) -> ResponseAction<'static> {
         ResponseAction::Error(message)
     }

--- a/src/response.rs
+++ b/src/response.rs
@@ -214,7 +214,8 @@ impl<'a, 'b> Response<'a, 'b> {
         self.headers.as_ref().and_then(|h| h.get::<H>())
     }
 
-    ///Mutably borrow the plugin storage.
+    ///Mutably borrow the plugin storage. It can be used to communicate with
+    ///the response plugins.
     pub fn plugin_storage(&mut self) -> &mut AnyMap {
         self.plugin_storage.as_mut().expect("response used after drop")
     }
@@ -334,7 +335,8 @@ pub struct ResponseWriter<'a, 'b> {
 
 impl<'a, 'b> ResponseWriter<'a, 'b> {
 
-    ///Mutably borrow the plugin storage.
+    ///Mutably borrow the plugin storage. It can be used to communicate with
+    ///the response plugins.
     pub fn plugin_storage(&mut self) -> &mut AnyMap {
         &mut self.plugin_storage
     }

--- a/src/response.rs
+++ b/src/response.rs
@@ -14,9 +14,11 @@ use hyper::net::Fresh;
 use hyper::http::HttpWriter;
 use hyper::version::HttpVersion;
 
+use anymap::AnyMap;
+
 use StatusCode;
 
-use plugin::ResponsePlugin;
+use plugin::{PluginContext, ResponsePlugin};
 use plugin::ResponseAction as Action;
 use log::Log;
 
@@ -177,7 +179,8 @@ pub struct Response<'a, 'b> {
     version: Option<HttpVersion>,
     writer: Option<HttpWriter<&'a mut (io::Write + 'a)>>,
     plugins: &'b Vec<Box<ResponsePlugin + Send + Sync>>,
-    log: &'b (Log + 'b)
+    log: &'b (Log + 'b),
+    plugin_storage: Option<AnyMap>
 }
 
 impl<'a, 'b> Response<'a, 'b> {
@@ -189,7 +192,8 @@ impl<'a, 'b> Response<'a, 'b> {
             version: Some(version),
             writer: Some(writer),
             plugins: plugins,
-            log: log
+            log: log,
+            plugin_storage: Some(AnyMap::new())
         }
     }
 
@@ -208,6 +212,11 @@ impl<'a, 'b> Response<'a, 'b> {
     ///Get a HTTP response header if set.
     pub fn get_header<H: Header + HeaderFormat>(&self) -> Option<&H> {
         self.headers.as_ref().and_then(|h| h.get::<H>())
+    }
+
+    ///Mutably borrow the plugin storage.
+    pub fn plugin_storage(&mut self) -> &mut AnyMap {
+        self.plugin_storage.as_mut().expect("response used after drop")
     }
 
     ///Turn the `Response` into a `ResponseWriter` to allow the response body to be written.
@@ -229,13 +238,27 @@ impl<'a, 'b> Response<'a, 'b> {
                 (status, headers, r) => {
                     write_queue.push(r);
 
-                    match plugin.begin(self.log, status, headers) {
+                    let plugin_res = {
+                        let plugin_context = PluginContext {
+                            storage: self.plugin_storage(),
+                            log: self.log
+                        };
+                        plugin.begin(plugin_context, status, headers)
+                    };
+
+                    match plugin_res {
                         (status, headers, Action::Error(e)) => (status, headers, Action::Error(e)),
                         (status, headers, result) => {
                             let mut error = None;
                             
                             write_queue = write_queue.into_iter().filter_map(|action| match action {
-                                Action::Write(content) => Some(plugin.write(self.log, content)),
+                                Action::Write(content) => {
+                                    let plugin_context = PluginContext {
+                                        storage: self.plugin_storage(),
+                                        log: self.log
+                                    };
+                                    Some(plugin.write(plugin_context, content))
+                                },
                                 Action::DoNothing => None,
                                 Action::Error(e) => {
                                     error = Some(e);
@@ -284,7 +307,8 @@ impl<'a, 'b> Response<'a, 'b> {
         ResponseWriter {
             writer: Some(writer),
             plugins: self.plugins,
-            log: self.log
+            log: self.log,
+            plugin_storage: self.plugin_storage.take().expect("response used after drop")
         }
     }
 }
@@ -304,10 +328,16 @@ impl<'a, 'b> Drop for Response<'a, 'b> {
 pub struct ResponseWriter<'a, 'b> {
     writer: Option<Result<hyper::server::response::Response<'a, hyper::net::Streaming>, ResponseError>>,
     plugins: &'b Vec<Box<ResponsePlugin + Send + Sync>>,
-    log: &'b (Log + 'b)
+    log: &'b (Log + 'b),
+    plugin_storage: AnyMap
 }
 
 impl<'a, 'b> ResponseWriter<'a, 'b> {
+
+    ///Mutably borrow the plugin storage.
+    pub fn plugin_storage(&mut self) -> &mut AnyMap {
+        &mut self.plugin_storage
+    }
 
     ///Writes response body data to the client.
     pub fn send<'d, Content: IntoResponseData<'d>>(&mut self, content: Content) -> Result<usize, ResponseError> {
@@ -323,7 +353,13 @@ impl<'a, 'b> ResponseWriter<'a, 'b> {
 
         for plugin in self.plugins {
             plugin_result = match plugin_result {
-                Action::Write(content) => plugin.write(self.log, content),
+                Action::Write(content) => {
+                    let plugin_context = PluginContext {
+                        storage: &mut self.plugin_storage,
+                        log: self.log
+                    };
+                    plugin.write(plugin_context, content)
+                },
                 _ => break
             }
         }
@@ -364,7 +400,13 @@ impl<'a, 'b> ResponseWriter<'a, 'b> {
         for plugin in self.plugins {
             let mut error = None;
             write_queue = write_queue.into_iter().filter_map(|action| match action {
-                Action::Write(content) => Some(plugin.write(self.log, content)),
+                Action::Write(content) => {
+                    let plugin_context = PluginContext {
+                        storage: &mut self.plugin_storage,
+                        log: self.log
+                    };
+                    Some(plugin.write(plugin_context, content))
+                },
                 Action::DoNothing => None,
                 Action::Error(e) => {
                     error = Some(e);
@@ -374,7 +416,13 @@ impl<'a, 'b> ResponseWriter<'a, 'b> {
 
             match error {
                 Some(e) => return Err(ResponseError::PluginError(e)),
-                None => write_queue.push(plugin.end(self.log))
+                None => {
+                    let plugin_context = PluginContext {
+                        storage: &mut self.plugin_storage,
+                        log: self.log
+                    };
+                    write_queue.push(plugin.end(plugin_context))
+                }
             }
         }
 


### PR DESCRIPTION
Current design uses AnyMap to store a request local state. This state is passed to the plugins when their methods are called and it's available to the handler through `Response` and `ResponseWriter`.

Closes #6.