### PR TITLE
Add support for global data

### DIFF
--- a/examples/post.rs
+++ b/examples/post.rs
@@ -1,0 +1,85 @@
+#[macro_use]
+extern crate rustful;
+
+use std::io::{self, Read};
+use std::fs::File;
+use std::path::Path;
+use std::borrow::Cow;
+use std::error::Error;
+
+use rustful::{Server, Context, Response, Log};
+use rustful::context::ExtQueryBody;
+use rustful::header::ContentType;
+use rustful::StatusCode::{InternalServerError, BadRequest};
+
+fn say_hello(mut context: Context, mut response: Response) {
+    response.set_header(ContentType(content_type!("text", "html", ("charset", "UTF-8"))));
+
+    let mut body = match context.read_query_body() {
+        Ok(body) => body,
+        Err(_) => {
+            //Oh no! Could not read the body
+            response.set_status(BadRequest);
+            return;
+        }
+    };
+
+    let files: &Files = if let Some(files) = context.global.downcast_ref() {
+        files
+    } else {
+        //Oh no! Why is the global data not a File instance?!
+        context.log.error("the global data should be of the type `Files`, but it's not");
+        response.set_status(InternalServerError);
+        return;
+    };
+
+    //Format the name or use the cached form
+    let content = if let Some(name) = body.remove("name") {
+        Cow::Owned(format!("<p>Hello, {}!</p>", name))
+    } else {
+        Cow::Borrowed(&files.form)
+    };
+
+    //Insert the content into the page and write it to the response
+    let complete_page = files.page.replace("{}", &content);
+    if let Err(e) = response.into_writer().send(complete_page) {
+        //There is not much we can do now
+        context.log.note(&format!("could not send page: {}", e.description()));
+    }
+    
+}
+
+fn main() {
+    println!("Visit http://localhost:8080 to try this example.");
+
+    //Preload the files
+    let files = Files {
+        page: read_string("examples/post/page.html").unwrap(),
+        form: read_string("examples/post/form.html").unwrap()
+    };
+
+    //Handlers implements the Router trait, so it can be passed to the server as it is
+    let server_result = Server {
+        host: 8080.into(),
+        global: Box::new(files),
+        ..Server::new(say_hello)
+    }.run();
+
+    //Check if the server started successfully
+    match server_result {
+        Ok(_server) => {},
+        Err(e) => println!("could not start server: {}", e.description())
+    }
+}
+
+fn read_string<P: AsRef<Path>>(path: P) -> io::Result<String> {
+    //Read file into a string
+    let mut string = String::new();
+    File::open(path).and_then(|mut f| f.read_to_string(&mut string)).map(|_| string)
+}
+
+//We want to store the files as strings
+struct Files {
+    page: String,
+    form: String
+}

--- a/examples/post.rs
+++ b/examples/post.rs
@@ -24,7 +24,7 @@ fn say_hello(mut context: Context, mut response: Response) {
         }
     };
 
-    let files: &Files = if let Some(files) = context.global.downcast_ref() {
+    let files: &Files = if let Some(files) = context.global() {
         files
     } else {
         //Oh no! Why is the global data not a File instance?!

--- a/examples/post.rs
+++ b/examples/post.rs
@@ -24,7 +24,7 @@ fn say_hello(mut context: Context, mut response: Response) {
         }
     };
 
-    let files: &Files = if let Some(files) = context.global() {
+    let files: &Files = if let Some(files) = context.global.get() {
         files
     } else {
         //Oh no! Why is the global data not a File instance?!
@@ -61,7 +61,7 @@ fn main() {
     //Handlers implements the Router trait, so it can be passed to the server as it is
     let server_result = Server {
         host: 8080.into(),
-        global: Box::new(files),
+        global: Box::new(files).into(),
         ..Server::new(say_hello)
     }.run();
 

--- a/examples/post/form.html
+++ b/examples/post/form.html
@@ -1,0 +1,8 @@
+<form method="post">
+	<div>
+		<label for="name">Name: </label><input id="name" type="text" name="name" />
+	</div>
+	<div>
+		<input type="submit" value="Say hello" />
+	</div>
+</form>

--- a/examples/post/page.html
+++ b/examples/post/page.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+
+<html charset="UTF-8">
+	<head>
+		<title>Hello</title>
+	</head>
+	<body>
+{}
+	</body>
+</html>

--- a/src/context.rs
+++ b/src/context.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 use std::io::{self, Read};
 use std::net::SocketAddr;
 use std::ops::{Deref, DerefMut};
+use std::any::Any;
 
 use hyper::http::HttpReader;
 use hyper::net::NetworkStream;
@@ -20,7 +21,7 @@ use log::Log;
 ///
 ///A `Context` can be dereferenced to a `BodyReader`, allowing direct access to
 ///the underlying read methods.
-pub struct Context<'a, 'b: 'a, 'l> {
+pub struct Context<'a, 'b: 'a, 's> {
     ///Headers from the HTTP request.
     pub headers: Headers,
 
@@ -46,13 +47,16 @@ pub struct Context<'a, 'b: 'a, 'l> {
     pub fragment: Option<String>,
 
     ///Log for notes, errors and warnings.
-    pub log: &'l (Log + 'l),
+    pub log: &'s (Log + 's),
+
+    ///Globally accessible data.
+    pub global: &'s Any,
 
     ///A reader for the request body.
-    pub body_reader: BodyReader<'a, 'b>
+    pub body_reader: BodyReader<'a, 'b>,
 }
 
-impl<'a, 'b, 'l> Deref for Context<'a, 'b, 'l> {
+impl<'a, 'b, 's> Deref for Context<'a, 'b, 's> {
     type Target = BodyReader<'a, 'b>;
 
     fn deref<'r>(&'r self) -> &'r BodyReader<'a, 'b> {
@@ -60,7 +64,7 @@ impl<'a, 'b, 'l> Deref for Context<'a, 'b, 'l> {
     }
 }
 
-impl<'a, 'b, 'l> DerefMut for Context<'a, 'b, 'l> {
+impl<'a, 'b, 's> DerefMut for Context<'a, 'b, 's> {
     fn deref_mut<'r>(&'r mut self) -> &'r mut BodyReader<'a, 'b> {
         &mut self.body_reader
     }

--- a/src/context.rs
+++ b/src/context.rs
@@ -56,6 +56,13 @@ pub struct Context<'a, 'b: 'a, 's> {
     pub body_reader: BodyReader<'a, 'b>,
 }
 
+impl<'a, 'b, 's> Context<'a, 'b, 's> {
+    ///Convenience method for downcasting the `global` field.
+    pub fn global<T: Any>(&self) -> Option<&T> {
+        self.global.downcast_ref()
+    }
+}
+
 impl<'a, 'b, 's> Deref for Context<'a, 'b, 's> {
     type Target = BodyReader<'a, 'b>;
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -4,7 +4,6 @@ use std::collections::HashMap;
 use std::io::{self, Read};
 use std::net::SocketAddr;
 use std::ops::{Deref, DerefMut};
-use std::any::Any;
 
 use hyper::http::HttpReader;
 use hyper::net::NetworkStream;
@@ -16,6 +15,8 @@ use HttpVersion;
 use Method;
 use header::Headers;
 use log::Log;
+
+use Global;
 
 ///A container for things like request data and cache.
 ///
@@ -50,17 +51,10 @@ pub struct Context<'a, 'b: 'a, 's> {
     pub log: &'s (Log + 's),
 
     ///Globally accessible data.
-    pub global: &'s Any,
+    pub global: &'s Global,
 
     ///A reader for the request body.
     pub body_reader: BodyReader<'a, 'b>,
-}
-
-impl<'a, 'b, 's> Context<'a, 'b, 's> {
-    ///Convenience method for downcasting the `global` field.
-    pub fn global<T: Any>(&self) -> Option<&T> {
-        self.global.downcast_ref()
-    }
 }
 
 impl<'a, 'b, 's> Deref for Context<'a, 'b, 's> {

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -1,5 +1,7 @@
 //!Request and context filters.
 
+use std::any::Any;
+
 use anymap::AnyMap;
 
 use StatusCode;
@@ -18,7 +20,10 @@ pub struct FilterContext<'a> {
     pub storage: &'a mut AnyMap,
 
     ///Log for notes, errors and warnings.
-    pub log: &'a Log
+    pub log: &'a Log,
+
+    ///Globally accessible data.
+    pub global: &'a Any,
 }
 
 ///A trait for context filters.

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -26,6 +26,13 @@ pub struct FilterContext<'a> {
     pub global: &'a Any,
 }
 
+impl<'a> FilterContext<'a> {
+    ///Convenience method for downcasting the `global` field.
+    pub fn global<T: Any>(&self) -> Option<&T> {
+        self.global.downcast_ref()
+    }
+}
+
 ///A trait for context filters.
 ///
 ///They are able to modify and react to a `Context` before it's sent to the handler.

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -1,7 +1,5 @@
 //!Request and context filters.
 
-use std::any::Any;
-
 use anymap::AnyMap;
 
 use StatusCode;
@@ -11,6 +9,8 @@ use context::Context;
 use log::Log;
 
 use response::Data;
+
+use Global;
 
 ///Contextual tools for filters.
 pub struct FilterContext<'a> {
@@ -23,14 +23,7 @@ pub struct FilterContext<'a> {
     pub log: &'a Log,
 
     ///Globally accessible data.
-    pub global: &'a Any,
-}
-
-impl<'a> FilterContext<'a> {
-    ///Convenience method for downcasting the `global` field.
-    pub fn global<T: Any>(&self) -> Option<&T> {
-        self.global.downcast_ref()
-    }
+    pub global: &'a Global,
 }
 
 ///A trait for context filters.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,12 +147,25 @@ impl FromStr for Host {
     }
 }
 
-///Globally accessible data.
+///Container for globally accessible data.
 ///
-///This structure can currently only hold either one item or nothing.
-///A future version will be able to hold multiple items.
+///It should only be created using `Global::default()`/`Default::default()` or
+///`Box::new(v).into()`.
+///
+///```
+///# use rustful::Global;
+///let g: Global = Box::new(5).into();
+///assert_eq!(g.get(), Some(&5));
+///```
+///
+///Direct manipulation of its variants may cause an undesired state.
+///
+///_Note: This structure can currently only hold either one item or nothing.
+///A future version will be able to hold multiple items._
 pub enum Global {
+    #[doc(hidden)]
     None,
+    #[doc(hidden)]
     One(Box<Any + Send + Sync>),
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,7 +161,7 @@ impl Global {
     pub fn get<T: Any + Send + Sync>(&self) -> Option<&T> {
         match self {
             &Global::None => None,
-            &Global::One(ref a) => (a as &Any).downcast_ref(),
+            &Global::One(ref a) => (&**a as &Any).downcast_ref(),
         }
     }
 }

--- a/src/response.rs
+++ b/src/response.rs
@@ -7,7 +7,6 @@ use std::borrow::Cow;
 use std::convert::From;
 use std::str::{from_utf8, Utf8Error};
 use std::string::{FromUtf8Error};
-use std::any::Any;
 
 use hyper;
 use hyper::header::{Headers, Header, HeaderFormat};
@@ -22,6 +21,8 @@ use StatusCode;
 use filter::{FilterContext, ResponseFilter};
 use filter::ResponseAction as Action;
 use log::Log;
+
+use Global;
 
 ///The result of a response action.
 #[derive(Debug)]
@@ -142,7 +143,7 @@ pub struct Response<'a, 'b> {
     writer: Option<HttpWriter<&'a mut (io::Write + 'a)>>,
     filters: &'b Vec<Box<ResponseFilter + Send + Sync>>,
     log: &'b (Log + 'b),
-    global: &'b Any,
+    global: &'b Global,
     filter_storage: Option<AnyMap>
 }
 
@@ -151,7 +152,7 @@ impl<'a, 'b> Response<'a, 'b> {
         response: hyper::server::response::Response<'a>,
         filters: &'b Vec<Box<ResponseFilter + Send + Sync>>,
         log: &'b Log,
-        global: &'b Any
+        global: &'b Global
     ) -> Response<'a, 'b> {
         let (version, writer, status, headers) = response.deconstruct();
         Response {
@@ -302,7 +303,7 @@ pub struct ResponseWriter<'a, 'b> {
     writer: Option<Result<hyper::server::response::Response<'a, hyper::net::Streaming>, Error>>,
     filters: &'b Vec<Box<ResponseFilter + Send + Sync>>,
     log: &'b (Log + 'b),
-    global: &'b Any,
+    global: &'b Global,
     filter_storage: AnyMap
 }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -3,6 +3,7 @@
 use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::borrow::ToOwned;
+use std::any::Any;
 
 use time;
 
@@ -80,6 +81,9 @@ pub struct Server<'s, R> {
     ///Tool for printing to a log. The default is to print to standard output.
     pub log: Box<Log + Send + Sync>,
 
+    ///Globally accessible data.
+    pub global: Box<Any + Send + Sync>,
+
     ///The context filter stack.
     pub context_filters: Vec<Box<ContextFilter + Send + Sync>>,
 
@@ -121,7 +125,8 @@ impl<'s, R, H> Server<'s, R>
             ),
             log: Box::new(StdOut),
             context_filters: Vec::new(),
-            response_filters: Vec::new()
+            response_filters: Vec::new(),
+            global: Box::new(())
         }
     }
 
@@ -151,6 +156,7 @@ impl<'s, R, H> Server<'s, R>
             log: self.log,
             context_filters: self.context_filters,
             response_filters: self.response_filters,
+            global: self.global,
         },
         self.scheme)
     }
@@ -195,7 +201,9 @@ pub struct ServerInstance<R> {
     log: Box<Log + Send + Sync>,
 
     context_filters: Vec<Box<ContextFilter + Send + Sync>>,
-    response_filters: Vec<Box<ResponseFilter + Send + Sync>>
+    response_filters: Vec<Box<ResponseFilter + Send + Sync>>,
+
+    global: Box<Any + Send + Sync>
 }
 
 impl<R> ServerInstance<R> {
@@ -208,7 +216,8 @@ impl<R> ServerInstance<R> {
                 ContextAction::Next => {
                     let filter_context = FilterContext {
                         storage: filter_storage,
-                        log: &*self.log
+                        log: &*self.log,
+                        global: &*self.global,
                     };
                     filter.modify(filter_context, context)
                 },
@@ -236,7 +245,7 @@ impl<R, H> HyperHandler for ServerInstance<R>
             request_reader
         ) = request.deconstruct();
 
-        let mut response = Response::new(writer, &self.response_filters, &*self.log);
+        let mut response = Response::new(writer, &self.response_filters, &*self.log, &*self.global);
         response.set_header(Date(HttpDate(time::now_utc())));
         response.set_header(ContentType(self.content_type.clone()));
         response.set_header(hyper::header::Server(self.server.clone()));
@@ -269,6 +278,7 @@ impl<R, H> HyperHandler for ServerInstance<R>
                     query: query,
                     fragment: fragment,
                     log: &*self.log,
+                    global: &*self.global,
                     body_reader: context::BodyReader::from_reader(request_reader)
                 };
 


### PR DESCRIPTION
Implements a shared storage for handlers and filters, as a field called `global` in `Server`, `Context` and `FilterContext`. This is only breaking if `Server` is instantiated by setting all of its fields or if `Context` or `FilterContext` are completely deconstructed.

Closes #25.