### PR TITLE
Add limited Windows tests using AppVeyor

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ Rustful
 =======
 
 [![Build Status](https://travis-ci.org/Ogeon/rustful.png?branch=master)](https://travis-ci.org/Ogeon/rustful)
+[![Windows Build status](https://ci.appveyor.com/api/projects/status/6a95paoex0eptbgn/branch/master?svg=true)](https://ci.appveyor.com/project/Ogeon/rustful/branch/master)
 
 A light web micro-framework for Rust. The main purpose of rustful is
 to create a simple, modular and non-intrusive foundation for HTTP

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,22 @@
+version: '{branch}-{build}'
+skip_tags: true
+platform: x64
+os: MinGW
+environment:
+  RUST_INSTALL_DIR: C:\Rust
+  RUST_INSTALL_TRIPLE: i686-pc-windows-gnu
+  RUST_VERSION: 1.0.0
+install:
+  - ps: Start-FileDownload "https://static.rust-lang.org/dist/rust-$Env:RUST_VERSION-$Env:RUST_INSTALL_TRIPLE.exe"
+  - cmd: rust-%RUST_VERSION%-%RUST_INSTALL_TRIPLE%.exe /VERYSILENT /NORESTART /COMPONENTS="rust,gcc,cargo" /DIR="%RUST_INSTALL_DIR%"
+  - cmd: SET PATH=%PATH%;%RUST_INSTALL_DIR%\bin;C:\MINGW\bin\
+  - rustc --version
+  - cargo --version
+  - ps: Start-FileDownload "http://slproweb.com/download/Win32OpenSSL-1_0_2a.exe"
+  - cmd: Win32OpenSSL-1_0_2a.exe /silent /verysilent /sp- /suppressmsgboxes
+  - cmd: SET OPENSSL_LIB_DIR=C:\OpenSSL-Win32
+  - cmd: SET OPENSSL_INCLUDE_DIR=C:\OpenSSL-Win32\include
+build: false
+test_script:
+  - cargo build --verbose
+  - cargo test --lib --verbose


### PR DESCRIPTION
Use AppVeyor to run CI tests for Windows. Documentation tests are disabled until rust-lang/cargo#1592 is fixed.