### PR TITLE
Enhance the insert_routes! macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,11 +83,11 @@ fn main() {
         handlers: insert_routes!{
             TreeRouter::new() => {
                 //Handle requests for root...
-                "/" => Get: HandlerFn(say_hello),
+                Get: HandlerFn(say_hello),
 
                 //...and one level below.
                 //`:person` is a path variable and it will be accessible in the handler.
-                "/:person" => Get: HandlerFn(say_hello)
+                ":person" => Get: HandlerFn(say_hello)
             }
         },
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@ extern crate rustful;
 use std::error::Error;
 
 use rustful::{Server, Context, Response, TreeRouter, Handler};
-use rustful::Method::Get;
 
 fn say_hello(context: Context, response: Response) {
     //Get the value of the path variable `:person`, from below.

--- a/examples/filters.rs
+++ b/examples/filters.rs
@@ -46,7 +46,7 @@ fn main() {
     insert_routes!{
         &mut router => {
             "print" => {
-                "/" => Get: HandlerFn(say_hello),
+                Get: HandlerFn(say_hello),
                 ":person" => Get: HandlerFn(say_hello)
             }
         }

--- a/examples/filters.rs
+++ b/examples/filters.rs
@@ -7,7 +7,6 @@ use std::error::Error;
 use rustful::{Server, TreeRouter, Context, Response, Log, Handler};
 use rustful::filter::{FilterContext, ResponseFilter, ResponseAction, ContextFilter, ContextAction};
 use rustful::response::Data;
-use rustful::Method::Get;
 use rustful::StatusCode;
 use rustful::header::Headers;
 

--- a/examples/handler_storage.rs
+++ b/examples/handler_storage.rs
@@ -29,22 +29,22 @@ fn main() {
 
     let router = insert_routes!{
         TreeRouter::new() => {
-            "/" => Get: Api::Counter {
+            Get: Api::Counter {
                 page: page.clone(),
                 value: value.clone(),
                 operation: None
             },
-            "/add" => Get: Api::Counter {
+            "add" => Get: Api::Counter {
                 page: page.clone(),
                 value: value.clone(),
                 operation: Some(add)
             },
-            "/sub" => Get: Api::Counter {
+            "sub" => Get: Api::Counter {
                 page: page.clone(),
                 value: value.clone(),
                 operation: Some(sub)
             },
-            "/res/:file" => Get: Api::File
+            "res/:file" => Get: Api::File
         }
     };
 

--- a/examples/handler_storage.rs
+++ b/examples/handler_storage.rs
@@ -15,7 +15,6 @@ use rustful::{
     TreeRouter,
     StatusCode
 };
-use rustful::Method::Get;
 use rustful::file::{self, Loader};
 
 fn main() {

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -39,11 +39,11 @@ fn main() {
         handlers: insert_routes!{
             TreeRouter::new() => {
                 //Handle requests for root...
-                "/" => Get: HandlerFn(say_hello),
+                Get: HandlerFn(say_hello),
 
                 //...and one level below.
                 //`:person` is a path variable and it will be accessible in the handler.
-                "/:person" => Get: HandlerFn(say_hello)
+                ":person" => Get: HandlerFn(say_hello)
             }
         },
 

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -5,7 +5,6 @@ extern crate rustful;
 use std::error::Error;
 
 use rustful::{Server, Context, Response, TreeRouter, Handler};
-use rustful::Method::Get;
 
 fn say_hello(context: Context, response: Response) {
     //Get the value of the path variable `:person`, from below.

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -10,8 +10,8 @@
 ///```rust
 ///#[macro_use]
 ///extern crate rustful;
-///use rustful::Method::Get;
-///# use rustful::{Handler, Context, Response, TreeRouter};
+///use rustful::TreeRouter;
+///# use rustful::{Handler, Context, Response};
 ///
 ///# struct DummyHandler;
 ///# impl Handler for DummyHandler {
@@ -40,8 +40,8 @@
 ///```rust
 ///#[macro_use]
 ///extern crate rustful;
-///use rustful::Method::{Get, Post, Delete};
-///# use rustful::{Handler, Context, Response, TreeRouter};
+///use rustful::TreeRouter;
+///# use rustful::{Handler, Context, Response};
 ///
 ///# #[derive(Clone, Copy)]
 ///# struct DummyHandler;
@@ -114,28 +114,48 @@ macro_rules! __rustful_insert_internal {
     };
     ($router:ident, [$($steps:expr),*], $($method:tt)::+: $handler:expr, $($next:tt)*) => {
         {
+            let method = {
+                #[allow(unused_imports)]
+                use $crate::Method::*;
+                __rustful_to_path!($($method)::+)
+            };
             let path = __rustful_route_expr!($($steps),*);
-            $router.insert(__rustful_to_path!($($method)::+), path, $handler);
+            $router.insert(method, path, $handler);
             __rustful_insert_internal!($router, [$($steps),*], $($next)*)
         }
     };
     ($router:ident, [$($steps:expr),*], $path:tt => $method:path: $handler:expr, $($next:tt)*) => {
         {
+            let method = {
+                #[allow(unused_imports)]
+                use $crate::Method::*;
+                $method
+            };
             let path = __rustful_route_expr!($($steps,)* __rustful_to_expr!($path));
-            $router.insert($method, path, $handler);
+            $router.insert(method, path, $handler);
             __rustful_insert_internal!($router, [$($steps),*], $($next)*)
         }
     };
     ($router:ident, [$($steps:expr),*], $($method:tt)::+: $handler:expr) => {
         {
+            let method = {
+                #[allow(unused_imports)]
+                use $crate::Method::*;
+                __rustful_to_path!($($method)::+)
+            };
             let path = __rustful_route_expr!($($steps),*);
-            $router.insert(__rustful_to_path!($($method)::+), path, $handler);
+            $router.insert(method, path, $handler);
         }
     };
     ($router:ident, [$($steps:expr),*], $path:tt => $method:path: $handler:expr) => {
         {
+            let method = {
+                #[allow(unused_imports)]
+                use $crate::Method::*;
+                $method
+            };
             let path = __rustful_route_expr!($($steps,)* __rustful_to_expr!($path));
-            $router.insert($method, path, $handler);
+            $router.insert(method, path, $handler);
         }
     };
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -101,6 +101,7 @@ macro_rules! insert_routes {
 #[doc(hidden)]
 #[macro_export]
 macro_rules! __rustful_insert_internal {
+    ($router:ident, [$($steps:expr),*],$(,)*) => {{}};
     ($router:ident, [$($steps:expr),*], $path:expr => {$($paths:tt)+}, $($next:tt)*) => {
         {
             __rustful_insert_internal!($router, [$($steps,)* $path], $($paths)*);

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -25,11 +25,11 @@
 ///# let show_welcome = DummyHandler;
 ///let router = insert_routes! {
 ///    TreeRouter::new() => {
+///        "/" => Get: show_welcome,
 ///        "/about" => Get: about_us,
 ///        "/user/:user" => Get: show_user,
 ///        "/product/:name" => Get: show_product,
-///        "/*" => Get: show_error,
-///        "/" => Get: show_welcome
+///        "/*" => Get: show_error
 ///    }
 ///};
 ///# }
@@ -62,20 +62,21 @@
 ///
 ///insert_routes! {
 ///    &mut router => {
-///        "/" => Get: show_home,
+///        Get: show_home,
+///
 ///        "home" => Get: show_home,
 ///        "user/:username" => {
-///            "/" => Get: show_user,
-///            "/" => Post: save_user
+///            Get: show_user,
+///            Post: save_user
 ///        },
 ///        "product" => {
-///            "/" => Get: show_all_products,
+///            Get: show_all_products,
 ///
 ///            "json" => Get: send_all_product_data,
 ///            ":id" => {
-///                "/" => Get: show_product,
-///                "/" => Post: edit_product,
-///                "/" => Delete: edit_product,
+///                Get: show_product,
+///                Post: edit_product,
+///                Delete: edit_product,
 ///
 ///                "json" => Get: send_product_data
 ///            }
@@ -106,22 +107,44 @@ macro_rules! __rustful_insert_internal {
             __rustful_insert_internal!($router, [$($steps),*], $($next)*);
         }
     };
-    ($router:ident, [$($steps:expr),*], $path:expr => {$($paths:tt)+}) => {
+    ($router:ident, [$($steps:expr),*], $path:tt => {$($paths:tt)+}) => {
         {
-            __rustful_insert_internal!($router, [$($steps,)* $path], $($paths)*);
+            __rustful_insert_internal!($router, [$($steps,)* __rustful_to_expr!($path)], $($paths)*);
         }
     };
-    ($router:ident, [$($steps:expr),*], $path:expr => $method:path: $handler:expr, $($next:tt)*) => {
+    ($router:ident, [$($steps:expr),*], $($method:tt)::+: $handler:expr, $($next:tt)*) => {
         {
-            $router.insert($method, &[$($steps,)* $path][..], $handler);
+            let path = __rustful_route_expr!($($steps),*);
+            $router.insert(__rustful_to_path!($($method)::+), path, $handler);
             __rustful_insert_internal!($router, [$($steps),*], $($next)*)
         }
     };
-    ($router:ident, [$($steps:expr),*], $path:expr => $method:path: $handler:expr) => {
+    ($router:ident, [$($steps:expr),*], $path:tt => $method:path: $handler:expr, $($next:tt)*) => {
         {
-            $router.insert($method, &[$($steps,)* $path][..], $handler);
+            let path = __rustful_route_expr!($($steps,)* __rustful_to_expr!($path));
+            $router.insert($method, path, $handler);
+            __rustful_insert_internal!($router, [$($steps),*], $($next)*)
         }
     };
+    ($router:ident, [$($steps:expr),*], $($method:tt)::+: $handler:expr) => {
+        {
+            let path = __rustful_route_expr!($($steps),*);
+            $router.insert(__rustful_to_path!($($method)::+), path, $handler);
+        }
+    };
+    ($router:ident, [$($steps:expr),*], $path:tt => $method:path: $handler:expr) => {
+        {
+            let path = __rustful_route_expr!($($steps,)* __rustful_to_expr!($path));
+            $router.insert($method, path, $handler);
+        }
+    };
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __rustful_route_expr {
+    () => ("");
+    ($($path:expr),+) => (&[$($path),+][..]);
 }
 
 /**
@@ -227,6 +250,12 @@ macro_rules! content_type {
 #[macro_export]
 macro_rules! __rustful_to_expr {
     ($e: expr) => ($e)
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __rustful_to_path {
+    ($e: path) => ($e)
 }
 
 use std::str::FromStr;

--- a/src/router/mod.rs
+++ b/src/router/mod.rs
@@ -8,7 +8,6 @@
 //!```
 //!#[macro_use]
 //!extern crate rustful;
-//!use rustful::Method::Get;
 //!use rustful::TreeRouter;
 //!# use rustful::{Handler, Context, Response};
 //!

--- a/src/router/mod.rs
+++ b/src/router/mod.rs
@@ -3,7 +3,7 @@
 //!Rustful provides a tree structured all-round router called `TreeRouter`,
 //!but any other type of router can be used, as long as it implements the
 //!`Router` trait. This will also make it possible to initialize it using the
-//!`insert_routes!` macro:
+//![`insert_routes!`][insert_routes] macro:
 //!
 //!```
 //!#[macro_use]
@@ -24,19 +24,19 @@
 //!# let list_products = DummyHandler;
 //!# let show_error = DummyHandler;
 //!# let show_welcome = DummyHandler;
-//!let router = insert_routes!{
+//!let router = insert_routes! {
 //!    TreeRouter::new() => {
-//!        "/about" => Get: about_us,
-//!        "/users" => {
-//!            "/" => Get: list_users,
+//!        Get: show_welcome,
+//!        "about" => Get: about_us,
+//!        "users" => {
+//!            Get: list_users,
 //!            ":id" => Get: show_user
 //!        },
-//!        "/products" => {
-//!            "/" => Get: list_products,
+//!        "products" => {
+//!            Get: list_products,
 //!            ":id" => Get: show_product
 //!        },
-//!        "/*" => Get: show_error,
-//!        "/" => Get: show_welcome
+//!        "*" => Get: show_error
 //!    }
 //!};
 //!# }
@@ -69,15 +69,17 @@
 //!# let show_welcome = DummyHandler;
 //!let mut router = TreeRouter::new();
 //!
+//!router.insert(Get, "/", show_welcome);
 //!router.insert(Get, "/about", about_us);
 //!router.insert(Get, "/users", list_users);
 //!router.insert(Get, "/users/:id", show_user);
 //!router.insert(Get, "/products", list_products);
 //!router.insert(Get, "/products/:id", show_product);
 //!router.insert(Get, "/*", show_error);
-//!router.insert(Get, "/", show_welcome);
 //!# }
 //!```
+//!
+//![insert_routes]: ../macro.insert_routes!.html
 
 use std::collections::HashMap;
 use std::iter::{Iterator, FlatMap};


### PR DESCRIPTION
Make `insert_routes!` nicer to use. This won't really break anything, but it will produce warnings if imported variants from `Method` were only used when calling the macro.

 * Make the path segment before the method optional. Makes it possible to replace `"/" => Get: my_handler` with just `Get: my_handler`.
 * HTTP methods are implicitly imported within the macro (but not within handlers). They are the only accepted input, anyway.
 * Allow one or more trailing commas, to make the syntax more tolerant towards situations like where the last handler was removed, but the preceding comma was left behind.