### PR TITLE
Fixed size responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ fn say_hello(context: Context, response: Response) {
     };
 
     //Use the name from the path variable to say hello.
-    response.into_writer().send(format!("Hello, {}!", person));
+    response.send_only(format!("Hello, {}!", person));
 }
 
 //Dodge an ICE, related to functions as handlers.

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ fn say_hello(context: Context, response: Response) {
     };
 
     //Use the name from the path variable to say hello.
-    response.send_only(format!("Hello, {}!", person));
+    response.send(format!("Hello, {}!", person));
 }
 
 //Dodge an ICE, related to functions as handlers.

--- a/examples/filters.rs
+++ b/examples/filters.rs
@@ -10,10 +10,19 @@ use rustful::response::Data;
 use rustful::StatusCode;
 use rustful::header::Headers;
 
-fn say_hello(mut context: Context, mut response: Response) {
+fn say_hello(mut context: Context, mut response: Response, format: &Format) {
     //Take the name of the JSONP function from the query variables
-    if let Some(jsonp_name) = context.query.remove("jsonp") {
+    let mut quote_msg = if let Some(jsonp_name) = context.query.remove("jsonp") {
         response.filter_storage().insert(JsonpFn(jsonp_name));
+        true
+    } else {
+        false
+    };
+
+    //Is the format supposed to be a JSON structure? Then set a variable name
+    if let Format::Json = *format {
+        response.filter_storage().insert(JsonVar("message"));
+        quote_msg = true;
     }
 
     let person = match context.variables.get("person") {
@@ -21,32 +30,48 @@ fn say_hello(mut context: Context, mut response: Response) {
         None => "stranger"
     };
 
-    //Using `try_send` allows us to catch eventual errors from the filters.
+    let message = if quote_msg {
+        format!("\"Hello, {}!\"", person)
+    } else {
+        format!("Hello, {}!", person)
+    };
+
+    //Using `try_send_only` allows us to catch eventual errors from the filters.
     //This example should not produce any errors, so this is only for show.
-    if let Err(e) = response.into_writer().try_send(format!("{{\"message\": \"Hello, {}!\"}}", person))  {
+    if let Err(e) = response.try_send_only(message) {
         context.log.note(&format!("could not send hello: {}", e.description()));
     }
 }
 
+enum Format {
+    Json,
+    Text
+}
+
 //Dodge an ICE, related to functions as handlers.
-struct HandlerFn(fn(Context, Response));
+struct HandlerFn(fn(Context, Response, &Format), Format);
 
 impl Handler for HandlerFn {
     fn handle_request(&self, context: Context, response: Response) {
-        self.0(context, response);
+        self.0(context, response, &self.1);
     }
 }
 
 fn main() {
-    println!("Visit http://localhost:8080 or http://localhost:8080/Peter (if your name is Peter) to try this example.");
+    println!("Visit http://localhost:8080, http://localhost:8080/Peter or http://localhost:8080/json/Peter (if your name is Peter) to try this example.");
     println!("Append ?jsonp=someFunction to get a JSONP response.");
 
     let mut router = TreeRouter::new();
     insert_routes!{
         &mut router => {
             "print" => {
-                Get: HandlerFn(say_hello),
-                ":person" => Get: HandlerFn(say_hello)
+                Get: HandlerFn(say_hello, Format::Text),
+                ":person" => Get: HandlerFn(say_hello, Format::Text),
+
+                "json" => {
+                    Get: HandlerFn(say_hello, Format::Json),
+                    ":person" => Get: HandlerFn(say_hello, Format::Json)
+                }
             }
         }
     };
@@ -62,7 +87,7 @@ fn main() {
             Box::new(RequestLogger::new())
         ],
 
-        response_filters: vec![Box::new(Jsonp)],
+        response_filters: vec![Box::new(Jsonp), Box::new(Json)],
 
         ..Server::default()
     }.run();
@@ -112,6 +137,33 @@ impl ContextFilter for PathPrefix {
     fn modify(&self, _ctx: FilterContext, context: &mut Context) -> ContextAction {
         context.path = format!("/{}{}", self.prefix.trim_matches('/'), context.path);
         ContextAction::next()
+    }
+}
+
+struct JsonVar(&'static str);
+
+struct Json;
+
+impl ResponseFilter for Json {
+    fn begin(&self, ctx: FilterContext, status: StatusCode, _headers: &mut Headers) -> (StatusCode, ResponseAction) {
+        //Check if a JSONP function is defined and write the beginning of the call
+        let output = if let Some(&JsonVar(var)) = ctx.storage.get() {
+            Some(format!("{{\"{}\": ", var))
+        } else {
+            None
+        };
+
+        (status, ResponseAction::next(output))
+    }
+
+    fn write<'a>(&'a self, _ctx: FilterContext, bytes: Option<Data<'a>>) -> ResponseAction {
+        ResponseAction::next(bytes)
+    }
+
+    fn end(&self, ctx: FilterContext) -> ResponseAction {
+        //Check if a JSONP function is defined and write the end of the call
+        let output = ctx.storage.get::<JsonVar>().map(|_| "}");
+        ResponseAction::next(output)
     }
 }
 

--- a/examples/filters.rs
+++ b/examples/filters.rs
@@ -13,7 +13,7 @@ use rustful::header::Headers;
 fn say_hello(mut context: Context, mut response: Response, format: &Format) {
     //Take the name of the JSONP function from the query variables
     let mut quote_msg = if let Some(jsonp_name) = context.query.remove("jsonp") {
-        response.filter_storage().insert(JsonpFn(jsonp_name));
+        response.filter_storage_mut().insert(JsonpFn(jsonp_name));
         true
     } else {
         false
@@ -21,7 +21,7 @@ fn say_hello(mut context: Context, mut response: Response, format: &Format) {
 
     //Is the format supposed to be a JSON structure? Then set a variable name
     if let Format::Json = *format {
-        response.filter_storage().insert(JsonVar("message"));
+        response.filter_storage_mut().insert(JsonVar("message"));
         quote_msg = true;
     }
 

--- a/examples/filters.rs
+++ b/examples/filters.rs
@@ -36,9 +36,9 @@ fn say_hello(mut context: Context, mut response: Response, format: &Format) {
         format!("Hello, {}!", person)
     };
 
-    //Using `try_send_only` allows us to catch eventual errors from the filters.
+    //Using `try_send` allows us to catch eventual errors from the filters.
     //This example should not produce any errors, so this is only for show.
-    if let Err(e) = response.try_send_only(message) {
+    if let Err(e) = response.try_send(message) {
         context.log.note(&format!("could not send hello: {}", e.description()));
     }
 }

--- a/examples/handler_storage.rs
+++ b/examples/handler_storage.rs
@@ -99,7 +99,7 @@ impl Handler for Api {
 
                 //Insert the value into the page and write it to the response
                 let count = value.read().unwrap().to_string();
-                response.into_writer().send(page.replace("{}", &count[..]));
+                response.send_only(page.replace("{}", &count[..]));
             },
             Api::File => {
                 if let Some(file) = context.variables.get("file") {

--- a/examples/handler_storage.rs
+++ b/examples/handler_storage.rs
@@ -99,7 +99,7 @@ impl Handler for Api {
 
                 //Insert the value into the page and write it to the response
                 let count = value.read().unwrap().to_string();
-                response.send_only(page.replace("{}", &count[..]));
+                response.send(page.replace("{}", &count[..]));
             },
             Api::File => {
                 if let Some(file) = context.variables.get("file") {

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -14,7 +14,7 @@ fn say_hello(context: Context, response: Response) {
     };
 
     //Use the name from the path variable to say hello.
-    response.send_only(format!("Hello, {}!", person));
+    response.send(format!("Hello, {}!", person));
 }
 
 //Dodge an ICE, related to functions as handlers.

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -14,7 +14,7 @@ fn say_hello(context: Context, response: Response) {
     };
 
     //Use the name from the path variable to say hello.
-    response.into_writer().send(format!("Hello, {}!", person));
+    response.send_only(format!("Hello, {}!", person));
 }
 
 //Dodge an ICE, related to functions as handlers.

--- a/examples/post.rs
+++ b/examples/post.rs
@@ -39,7 +39,7 @@ fn say_hello(mut context: Context, mut response: Response) {
 
     //Insert the content into the page and write it to the response
     let complete_page = files.page.replace("{}", &content);
-    response.into_writer().send(complete_page);
+    response.send_only(complete_page);
 }
 
 //Dodge an ICE, related to functions as handlers.

--- a/examples/post.rs
+++ b/examples/post.rs
@@ -39,7 +39,7 @@ fn say_hello(mut context: Context, mut response: Response) {
 
     //Insert the content into the page and write it to the response
     let complete_page = files.page.replace("{}", &content);
-    response.send_only(complete_page);
+    response.send(complete_page);
 }
 
 //Dodge an ICE, related to functions as handlers.

--- a/src/context.rs
+++ b/src/context.rs
@@ -19,10 +19,9 @@
 //!
 //!fn my_handler(context: Context, response: Response) {
 //!    if let Some(&UserAgent(ref user_agent)) = context.headers.get() {
-//!        let res = format!("got user agent string \"{}\"", user_agent);
-//!        response.into_writer().send(res);
+//!        response.send_only(format!("got user agent string \"{}\"", user_agent));
 //!    } else {
-//!        response.into_writer().send("no user agent string provided");
+//!        response.send_only("no user agent string provided");
 //!    }
 //!}
 //!```
@@ -38,12 +37,11 @@
 //!
 //!fn my_handler(context: Context, response: Response) {
 //!    if let Some(id) = context.variables.get("id") {
-//!        let res = format!("asking for product with id \"{}\"", id);
-//!        response.into_writer().send(res);
+//!        response.send_only(format!("asking for product with id \"{}\"", id));
 //!    } else {
 //!        //This will usually not happen, unless the handler is also
 //!        //assigned to a path without the `id` variable
-//!        response.into_writer().send("no id provided");
+//!        response.send_only("no id provided");
 //!    }
 //!}
 //!```
@@ -72,7 +70,7 @@
 //!
 //!fn my_handler(context: Context, mut response: Response) {
 //!    match something_that_may_fail() {
-//!        Ok(res) => response.into_writer().send(res),
+//!        Ok(res) => response.send_only(res),
 //!        Err(e) => {
 //!            context.log.error(&format!("it failed! {}", e));
 //!            response.set_status(InternalServerError);
@@ -96,8 +94,7 @@
 //!
 //!fn my_handler(context: Context, mut response: Response) {
 //!    if let Some(some_wise_words) = context.global.get::<&str>() {
-//!        let res = format!("food for thought: {}", some_wise_words);
-//!        response.into_writer().send(res);
+//!        response.send_only(format!("food for thought: {}", some_wise_words));
 //!    } else {
 //!        context.log.error("there should be a string literal in `global`");
 //!        response.set_status(InternalServerError);
@@ -234,7 +231,7 @@ impl<'a, 'b> ExtQueryBody for BodyReader<'a, 'b> {
     ///    let a: f64 = query.get("a").and_then(|number| number.parse().ok()).unwrap();
     ///    let b: f64 = query.get("b").and_then(|number| number.parse().ok()).unwrap();
     ///
-    ///    response.into_writer().send(format!("{} + {} = {}", a, b, a + b));
+    ///    response.send_only(format!("{} + {} = {}", a, b, a + b));
     ///}
     ///```
     #[inline]
@@ -280,7 +277,7 @@ impl<'a, 'b> ExtJsonBody for BodyReader<'a, 'b> {
     ///    let a = json.find("a").and_then(|number| number.as_f64()).unwrap();
     ///    let b = json.find("b").and_then(|number| number.as_f64()).unwrap();
     ///
-    ///    response.into_writer().send(format!("{} + {} = {}", a, b, a + b));
+    ///    response.send_only(format!("{} + {} = {}", a, b, a + b));
     ///}
     ///```
     fn read_json_body(&mut self) -> Result<json::Json, json::BuilderError> {
@@ -309,8 +306,7 @@ impl<'a, 'b> ExtJsonBody for BodyReader<'a, 'b> {
     ///    //Decode a JSON formatted request body into Foo
     ///    let foo: Foo = context.body.decode_json_body().unwrap();
     ///
-    ///    let res = format!("{} + {} = {}", foo.a, foo.b, foo.a + foo.b);
-    ///    response.into_writer().send(res);
+    ///    response.send_only(format!("{} + {} = {}", foo.a, foo.b, foo.a + foo.b));
     ///}
     ///# fn main() {}
     ///```

--- a/src/context.rs
+++ b/src/context.rs
@@ -116,7 +116,7 @@
 //!
 //!fn my_handler(context: Context, response: Response) {
 //!    let mut numbered_lines = BufReader::new(context.body).lines().enumerate();
-//!    let mut writer = response.into_writer();
+//!    let mut writer = response.into_chunked();
 //!
 //!    while let Some((line_no, Ok(line))) = numbered_lines.next() {
 //!        writer.send(format!("{}: {}", line_no + 1, line));

--- a/src/context.rs
+++ b/src/context.rs
@@ -19,9 +19,9 @@
 //!
 //!fn my_handler(context: Context, response: Response) {
 //!    if let Some(&UserAgent(ref user_agent)) = context.headers.get() {
-//!        response.send_only(format!("got user agent string \"{}\"", user_agent));
+//!        response.send(format!("got user agent string \"{}\"", user_agent));
 //!    } else {
-//!        response.send_only("no user agent string provided");
+//!        response.send("no user agent string provided");
 //!    }
 //!}
 //!```
@@ -37,11 +37,11 @@
 //!
 //!fn my_handler(context: Context, response: Response) {
 //!    if let Some(id) = context.variables.get("id") {
-//!        response.send_only(format!("asking for product with id \"{}\"", id));
+//!        response.send(format!("asking for product with id \"{}\"", id));
 //!    } else {
 //!        //This will usually not happen, unless the handler is also
 //!        //assigned to a path without the `id` variable
-//!        response.send_only("no id provided");
+//!        response.send("no id provided");
 //!    }
 //!}
 //!```
@@ -70,7 +70,7 @@
 //!
 //!fn my_handler(context: Context, mut response: Response) {
 //!    match something_that_may_fail() {
-//!        Ok(res) => response.send_only(res),
+//!        Ok(res) => response.send(res),
 //!        Err(e) => {
 //!            context.log.error(&format!("it failed! {}", e));
 //!            response.set_status(InternalServerError);
@@ -94,7 +94,7 @@
 //!
 //!fn my_handler(context: Context, mut response: Response) {
 //!    if let Some(some_wise_words) = context.global.get::<&str>() {
-//!        response.send_only(format!("food for thought: {}", some_wise_words));
+//!        response.send(format!("food for thought: {}", some_wise_words));
 //!    } else {
 //!        context.log.error("there should be a string literal in `global`");
 //!        response.set_status(InternalServerError);
@@ -231,7 +231,7 @@ impl<'a, 'b> ExtQueryBody for BodyReader<'a, 'b> {
     ///    let a: f64 = query.get("a").and_then(|number| number.parse().ok()).unwrap();
     ///    let b: f64 = query.get("b").and_then(|number| number.parse().ok()).unwrap();
     ///
-    ///    response.send_only(format!("{} + {} = {}", a, b, a + b));
+    ///    response.send(format!("{} + {} = {}", a, b, a + b));
     ///}
     ///```
     #[inline]
@@ -277,7 +277,7 @@ impl<'a, 'b> ExtJsonBody for BodyReader<'a, 'b> {
     ///    let a = json.find("a").and_then(|number| number.as_f64()).unwrap();
     ///    let b = json.find("b").and_then(|number| number.as_f64()).unwrap();
     ///
-    ///    response.send_only(format!("{} + {} = {}", a, b, a + b));
+    ///    response.send(format!("{} + {} = {}", a, b, a + b));
     ///}
     ///```
     fn read_json_body(&mut self) -> Result<json::Json, json::BuilderError> {
@@ -306,7 +306,7 @@ impl<'a, 'b> ExtJsonBody for BodyReader<'a, 'b> {
     ///    //Decode a JSON formatted request body into Foo
     ///    let foo: Foo = context.body.decode_json_body().unwrap();
     ///
-    ///    response.send_only(format!("{} + {} = {}", foo.a, foo.b, foo.a + foo.b));
+    ///    response.send(format!("{} + {} = {}", foo.a, foo.b, foo.a + foo.b));
     ///}
     ///# fn main() {}
     ///```

--- a/src/file.rs
+++ b/src/file.rs
@@ -91,7 +91,7 @@ impl Loader {
             Err(e) => return Err(Error::Open(e, response))
         };
 
-        response.set_header(ContentType(mime));
+        response.headers_mut().set(ContentType(mime));
 
         let mut writer = unsafe { response.into_raw(metadata.len()) };
         let mut buffer = vec![0; self.buffer_size];

--- a/src/file.rs
+++ b/src/file.rs
@@ -4,7 +4,7 @@ use std::io::{self, Read};
 use std::fs::File;
 use std::path::Path;
 
-use response::{Response, Chunked};
+use response::Response;
 use mime::{Mime, TopLevel, SubLevel};
 use header::ContentType;
 
@@ -59,13 +59,13 @@ impl<'a> Into<SubLevel> for &'a MaybeKnown<SubLevel> {
 ///client.
 pub struct Loader {
     ///The size, in bytes, of the file chunks. Default is 1048576 (1 megabyte).
-    pub chunk_size: usize
+    pub buffer_size: usize
 }
 
 impl Loader {
     pub fn new() -> Loader {
         Loader {
-            chunk_size: 1048576
+            buffer_size: 1048576
         }
     }
 
@@ -86,16 +86,20 @@ impl Loader {
             Ok(file) => file,
             Err(e) => return Err(Error::Open(e, response))
         };
+        let metadata = match file.metadata() {
+            Ok(metadata) => metadata,
+            Err(e) => return Err(Error::Open(e, response))
+        };
 
         response.set_header(ContentType(mime));
 
-        let mut writer = response.into_chunked();
-        let mut buffer = vec![0; self.chunk_size];
+        let mut writer = unsafe { response.into_raw(metadata.len()) };
+        let mut buffer = vec![0; self.buffer_size];
         loop {
             match file.read(&mut buffer) {
                 Ok(len) if len == 0 => break,
-                Ok(len) => writer.send(&buffer[..len]),
-                Err(e) => return Err(Error::Read(e, writer))
+                Ok(len) => try!(writer.try_send(&buffer[..len]).map_err(|e| Error::Transfer(e))),
+                Err(e) => return Err(Error::Read(e))
             }
         }
 
@@ -108,14 +112,17 @@ pub enum Error<'a, 'b> {
     ///Failed to open the file.
     Open(io::Error, Response<'a, 'b>),
     ///Failed while reading the file.
-    Read(io::Error, Chunked<'a, 'b>)
+    Read(io::Error),
+    ///Failed while trasferring the file.
+    Transfer(io::Error)
 }
 
 impl<'a, 'b> Error<'a, 'b> {
     pub fn io_error(&self) -> &io::Error {
         match *self {
             Error::Open(ref e, _) => e,
-            Error::Read(ref e, _) => e
+            Error::Read(ref e) => e,
+            Error::Transfer(ref e) => e
         }
     }
 }

--- a/src/file.rs
+++ b/src/file.rs
@@ -4,7 +4,7 @@ use std::io::{self, Read};
 use std::fs::File;
 use std::path::Path;
 
-use response::{Response, ResponseWriter};
+use response::{Response, Chunked};
 use mime::{Mime, TopLevel, SubLevel};
 use header::ContentType;
 
@@ -89,7 +89,7 @@ impl Loader {
 
         response.set_header(ContentType(mime));
 
-        let mut writer = response.into_writer();
+        let mut writer = response.into_chunked();
         let mut buffer = vec![0; self.chunk_size];
         loop {
             match file.read(&mut buffer) {
@@ -108,7 +108,7 @@ pub enum Error<'a, 'b> {
     ///Failed to open the file.
     Open(io::Error, Response<'a, 'b>),
     ///Failed while reading the file.
-    Read(io::Error, ResponseWriter<'a, 'b>)
+    Read(io::Error, Chunked<'a, 'b>)
 }
 
 impl<'a, 'b> Error<'a, 'b> {

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -35,6 +35,7 @@ pub trait ContextFilter: Send + Sync {
 }
 
 ///The result from a context filter.
+#[derive(Clone)]
 pub enum ContextAction {
     ///Continue to the next filter in the stack.
     Next,
@@ -70,6 +71,7 @@ pub trait ResponseFilter: Send + Sync {
 }
 
 ///The result from a response filter.
+#[derive(Clone)]
 pub enum ResponseAction<'a> {
     ///Continue to the next filter and maybe write data.
     Next(Option<Data<'a>>),

--- a/src/response.rs
+++ b/src/response.rs
@@ -269,6 +269,11 @@ impl<'a, 'b> Response<'a, 'b> {
     ///will be called on the registered response filters.
     pub fn into_chunked(mut self) -> Chunked<'a, 'b> {
         let mut writer = self.writer.take().expect("response used after drop");
+        
+        //Make sure it's chunked
+        writer.headers_mut().remove::<::header::ContentLength>();
+        writer.headers_mut().remove_raw("content-length");
+
         let writer = filter_headers(
             self.filters,
             writer.status(),

--- a/src/response.rs
+++ b/src/response.rs
@@ -190,28 +190,28 @@ impl<'a, 'b> Response<'a, 'b> {
     ///use rustful::{Context, Response};
     ///
     ///fn my_handler(context: Context, response: Response) {
-    ///    response.send_only("hello");
+    ///    response.send("hello");
     ///}
     ///```
     #[allow(unused_must_use)]
-    pub fn send_only<'d, Content: Into<Data<'d>>>(self, content: Content) {
-        self.try_send_only(content);
+    pub fn send<'d, Content: Into<Data<'d>>>(self, content: Content) {
+        self.try_send(content);
     }
 
     ///Try to send data to the client and finish the response. This is the
-    ///same as `send_only`, but errors are not ignored.
+    ///same as `send`, but errors are not ignored.
     ///
     ///```
     ///use rustful::{Context, Response};
     ///use rustful::response::Error;
     ///
     ///fn my_handler(context: Context, response: Response) {
-    ///    if let Err(Error::Filter(e)) = response.try_send_only("hello") {
+    ///    if let Err(Error::Filter(e)) = response.try_send("hello") {
     ///        context.log.note(&format!("a filter failed: {}", e));
     ///    }
     ///}
     ///```
-    pub fn try_send_only<'d, Content: Into<Data<'d>>>(mut self, content: Content) -> Result<(), Error> {
+    pub fn try_send<'d, Content: Into<Data<'d>>>(mut self, content: Content) -> Result<(), Error> {
         self.send_sized(content)
     }
 


### PR DESCRIPTION
Implement support for responses with a fixed size. This includes adding send methods to `Response` and renaming `ResponseWriter` to `Chunked`. A new response type, called `Raw`, is also introduced, which makes it possible to stream data with a known length, such as large files.

This change does also include a change in how `file::Loader` changes data, some more documentation for the `response` module and general API polish for responses.

This will probably break every project. I'm surprised if it doesn't.

Closes #37