### PR TITLE
Implement support for multipart requests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ version = "0.6"
 default-features = false
 
 [dependencies.multipart]
-version = "0.2"
+version = "0.3"
 default-features = false
 features = ["server"]
 optional = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ name = "rustful"
 path = "src/lib.rs"
 
 [features]
-default = ["rustc_json_body", "ssl"]
+default = ["rustc_json_body", "ssl", "multipart"]
 benchmark = []
 rustc_json_body = ["rustc-serialize"]
 ssl = ["hyper/ssl"]
@@ -35,6 +35,7 @@ default-features = false
 version = "0.2"
 default-features = false
 features = ["server"]
+optional = true
 
 [dependencies.rustc-serialize]
 version = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,11 @@ phf = "0.7"
 version = "0.6"
 default-features = false
 
+[dependencies.multipart]
+version = "0.2"
+default-features = false
+features = ["server"]
+
 [dependencies.rustc-serialize]
 version = "0.3"
 optional = true

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Some parts of Rustful can be toggled using Cargo features:
 
  * `rustc_json_body` - Parse the request body as JSON. Enabled by default.
  * `ssl` - Enable SSL, and thereby HTTPS. Enabled by default.
+ * `multipart` - Enable parsing of `multipart/form-data` requests. Enabled by default.
 
 ##Write Your Server
 Here is a simple example of what a simple project could look like. Visit

--- a/src/context.rs
+++ b/src/context.rs
@@ -226,6 +226,44 @@ impl<'a, 'b> BodyReader<'a, 'b> {
         }
     }
 
+    ///Try to create a `multipart/form-data` reader from the request body.
+    ///
+    ///```
+    ///# extern crate rustful;
+    ///# extern crate multipart;
+    ///use std::fmt::Write;
+    ///use rustful::{Context, Response};
+    ///use rustful::StatusCode::BadRequest;
+    ///use multipart::server::MultipartData;
+    ///
+    ///fn my_handler(mut context: Context, mut response: Response) {
+    ///    if let Some(mut multipart) = context.body.as_multipart() {
+    ///        let mut result = String::new();
+    ///
+    ///        //Iterate over the multipart entries and print info about them in `result`
+    ///        multipart.foreach_entry(|entry| match entry.data {
+    ///            MultipartData::Text(text) => {
+    ///                //Found data from a text field
+    ///                writeln!(&mut result, "{}: '{}'", entry.name, text);
+    ///            },
+    ///            MultipartData::File(file) => {
+    ///                //Found an uploaded file
+    ///                if let Some(file_name) = file.filename() {
+    ///                    writeln!(&mut result, "{}: a file called '{}'", entry.name, file_name);
+    ///                } else {
+    ///                    writeln!(&mut result, "{}: a nameless file", entry.name);
+    ///                }
+    ///            }
+    ///        });
+    ///
+    ///        response.send(result);
+    ///    } else {
+    ///        //We expected it to be a valid `multipart/form-data` request, but it was not
+    ///        response.set_status(BadRequest);
+    ///    }
+    ///}
+    ///# fn main() {}
+    ///```
     pub fn as_multipart<'r>(&'r mut self) -> Option<Multipart<MultipartRequest<'r, 'a, 'b>>> {
         let reader = &mut self.reader;
         self.multipart_boundary.as_ref().and_then(move |boundary|

--- a/src/context.rs
+++ b/src/context.rs
@@ -417,11 +417,7 @@ pub struct MultipartRequest<'r, 'a: 'r, 'b: 'a> {
 
 #[cfg(feature = "multipart")]
 impl<'r, 'a, 'b> HttpRequest for MultipartRequest<'r, 'a, 'b> {
-    fn is_multipart(&self) -> bool {
-        true
-    }
-
-    fn boundary(&self) -> Option<&str> {
+    fn multipart_boundary(&self) -> Option<&str> {
         Some(self.boundary)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ extern crate time;
 extern crate hyper;
 extern crate anymap;
 extern crate phf;
+extern crate multipart;
 
 pub use hyper::mime;
 pub use hyper::method::Method;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,12 +16,14 @@ extern crate tempdir;
 #[cfg(feature = "rustc-serialize")]
 extern crate rustc_serialize;
 
+#[cfg(feature = "multipart")]
+extern crate multipart;
+
 extern crate url;
 extern crate time;
 extern crate hyper;
 extern crate anymap;
 extern crate phf;
-extern crate multipart;
 
 pub use hyper::mime;
 pub use hyper::method::Method;

--- a/src/server.rs
+++ b/src/server.rs
@@ -292,7 +292,10 @@ impl<R: Router> HyperHandler for ServerInstance<R> {
 
         match path_components {
             Some((path, query, fragment)) => {
-
+                let body = {
+                    let content_type = request_headers.get().map(|&ContentType(ref mime)| mime);
+                    context::BodyReader::from_reader(request_reader, content_type)
+                };
                 let mut context = Context {
                     headers: request_headers,
                     http_version: request_version,
@@ -305,7 +308,7 @@ impl<R: Router> HyperHandler for ServerInstance<R> {
                     fragment: fragment,
                     log: &*self.log,
                     global: &self.global,
-                    body: context::BodyReader::from_reader(request_reader)
+                    body: body
                 };
 
                 let mut filter_storage = AnyMap::new();

--- a/src/server.rs
+++ b/src/server.rs
@@ -292,10 +292,7 @@ impl<R: Router> HyperHandler for ServerInstance<R> {
 
         match path_components {
             Some((path, query, fragment)) => {
-                let body = {
-                    let content_type = request_headers.get().map(|&ContentType(ref mime)| mime);
-                    context::BodyReader::from_reader(request_reader, content_type)
-                };
+                let body = context::BodyReader::from_reader(request_reader, &request_headers);
                 let mut context = Context {
                     headers: request_headers,
                     http_version: request_version,


### PR DESCRIPTION
This adds support for requests with the type `multipart/form-data` to the `BodyReader`. The solution has also been discussed in #49 and (mainly) consists of adding an `as_multipart` method to `BodyReader` and a `multipart` cargo feature that toggles it.

The changes here breaks the `from_reader` method on `BodyReader`, which is really an internal method. I would like to consider it highly unstable for now, so this is still a minor change.

Closes #49