### PR TITLE
Bump Rust version for testing on Windows to 1.1.0

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,7 @@ os: MinGW
 environment:
   RUST_INSTALL_DIR: C:\Rust
   RUST_INSTALL_TRIPLE: i686-pc-windows-gnu
-  RUST_VERSION: 1.0.0
+  RUST_VERSION: 1.1.0
   OPENSSL_VERSION: 1_0_2d
 install:
   - ps: Start-FileDownload "https://static.rust-lang.org/dist/rust-$Env:RUST_VERSION-$Env:RUST_INSTALL_TRIPLE.exe"


### PR DESCRIPTION
This is to satisfy the latest requirements from `libwinapi`.