### PR TITLE
Implement a Parameters type

### DIFF
--- a/examples/todo.rs
+++ b/examples/todo.rs
@@ -113,7 +113,7 @@ fn get_todo(database: &Database, context: Context, mut response: Response) {
     let host = or_abort!(context.headers.get(), response, StatusCode::BadRequest);
 
     let id = or_abort!(
-        context.variables.get("id").and_then(|id| id.parse().ok()),
+        context.variables.parse("id").ok(),
         response,
         StatusCode::BadRequest
     );
@@ -136,7 +136,7 @@ fn edit_todo(database: &Database, mut context: Context, mut response: Response) 
     let host = or_abort!(context.headers.get(), response, StatusCode::BadRequest);
 
     let id = or_abort!(
-        context.variables.get("id").and_then(|id| id.parse().ok()),
+        context.variables.parse("id").ok(),
         response,
         StatusCode::BadRequest
     );
@@ -155,7 +155,7 @@ fn edit_todo(database: &Database, mut context: Context, mut response: Response) 
 //Delete a to-do, selected by its id
 fn delete_todo(database: &Database, context: Context, mut response: Response) {
     let id = or_abort!(
-        context.variables.get("id").and_then(|id| id.parse().ok()),
+        context.variables.parse("id").ok(),
         response,
         StatusCode::BadRequest
     );

--- a/src/context.rs
+++ b/src/context.rs
@@ -129,7 +129,6 @@
 //![log]: ../log/index.html
 //![body_reader]: struct.BodyReader.html
 
-use std::collections::HashMap;
 use std::io::{self, Read};
 use std::net::SocketAddr;
 
@@ -149,6 +148,7 @@ use utils;
 
 use HttpVersion;
 use Method;
+use Parameters;
 use header::Headers;
 use log::Log;
 
@@ -175,10 +175,10 @@ pub struct Context<'a, 'b: 'a, 's> {
     pub hypermedia: Hypermedia<'s>,
 
     ///Route variables.
-    pub variables: HashMap<String, String>,
+    pub variables: Parameters<String, String>,
 
     ///Query variables from the path.
-    pub query: HashMap<String, String>,
+    pub query: Parameters<String, String>,
 
     ///The fragment part of the URL (after #), if provided.
     pub fragment: Option<String>,
@@ -310,15 +310,15 @@ pub trait ExtQueryBody {
     ///    response.send(format!("{} + {} = {}", a, b, a + b));
     ///}
     ///```
-    fn read_query_body(&mut self) -> io::Result<HashMap<String, String>>;
+    fn read_query_body(&mut self) -> io::Result<Parameters<String, String>>;
 }
 
 impl<'a, 'b> ExtQueryBody for BodyReader<'a, 'b> {
     #[inline]
-    fn read_query_body(&mut self) -> io::Result<HashMap<String, String>> {
+    fn read_query_body(&mut self) -> io::Result<Parameters<String, String>> {
         let mut buf = Vec::new();
         try!(self.read_to_end(&mut buf));
-        Ok(utils::parse_parameters(&buf))
+        Ok(utils::parse_parameters(&buf).into())
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -366,6 +366,11 @@ enum GlobalState {
 pub struct Parameters<K, V>(HashMap<K, V>);
 
 impl<K: Hash + Eq, V: AsRef<str>> Parameters<K, V> {
+    ///Create an empty `Parameters`.
+    pub fn new() -> Parameters<K, V> {
+        Parameters(HashMap::new())
+    }
+
     ///Try to parse an entry as `T`, if it exists. The error will be `None` if
     ///the entry does not exist, and `Some` if it does exists, but the parsing
     ///failed.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -454,6 +454,18 @@ impl<K: Eq + Hash, V: AsRef<str>> DerefMut for Parameters<K, V> {
     }
 }
 
+impl<K: Eq + Hash, V: AsRef<str>> AsRef<HashMap<K, V>> for Parameters<K, V> {
+    fn as_ref(&self) -> &HashMap<K, V> {
+        &self.0
+    }
+}
+
+impl<K: Eq + Hash, V: AsRef<str>> AsMut<HashMap<K, V>> for Parameters<K, V> {
+    fn as_mut(&mut self) -> &mut HashMap<K, V> {
+        &mut self.0
+    }
+}
+
 impl<K: Eq + Hash, V: AsRef<str>> Into<HashMap<K, V>> for Parameters<K, V> {
     fn into(self) -> HashMap<K, V> {
         self.0

--- a/src/server.rs
+++ b/src/server.rs
@@ -301,8 +301,8 @@ impl<R: Router> HyperHandler for ServerInstance<R> {
                     address: request_addr,
                     path: lossy_utf8_percent_decode(&path),
                     hypermedia: Hypermedia::new(),
-                    variables: HashMap::new(),
-                    query: query,
+                    variables: HashMap::new().into(),
+                    query: query.into(),
                     fragment: fragment,
                     log: &*self.log,
                     global: &self.global,
@@ -321,7 +321,7 @@ impl<R: Router> HyperHandler for ServerInstance<R> {
                         } = self.handlers.find(&context.method, &context.path);
                         if let Some(handler) = handler.or(self.fallback_handler.as_ref()) {
                             context.hypermedia = hypermedia;
-                            context.variables = variables;
+                            context.variables = variables.into();
                             handler.handle_request(context, response);
                         } else {
                             response.set_status(StatusCode::NotFound);

--- a/src/server.rs
+++ b/src/server.rs
@@ -34,6 +34,7 @@ use Scheme;
 use Host;
 use Global;
 use HttpResult;
+use Parameters;
 
 use utils;
 
@@ -301,7 +302,7 @@ impl<R: Router> HyperHandler for ServerInstance<R> {
                     address: request_addr,
                     path: lossy_utf8_percent_decode(&path),
                     hypermedia: Hypermedia::new(),
-                    variables: HashMap::new().into(),
+                    variables: Parameters::new(),
                     query: query.into(),
                     fragment: fragment,
                     log: &*self.log,


### PR DESCRIPTION
This PR adds a `Patameters` type that extends `HashMap` with helpful parsing methods. This allows parameters to easily be parsed as any type `T: FromStr` without repeating `map(|v| v.parse().ok())` or anything similar.

Part of the purpose of this PR is to see how sane it is to implement this as a separate type, instead of a trait. Thoughts, ideas and feedback are most welcome.

This replaces some occurrences of `HashMap` with `Parameters`, which makes it a breaking change.

Closes #55