### PR TITLE
Test more and forbid warnings and missing docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,9 @@ cache:
   directories:
     - $HOME/.cargo
 rust:
-  - 1.0.0
+  - stable
+  - beta
+  - nightly
 os:
   - linux
   - osx
@@ -14,8 +16,8 @@ branches:
     - auto
 script:
   - cargo build -v --features strict
-  - cargo build -v --no-default-features --features strict
   - cargo test -v --features strict
+  - sh scripts/test_features.sh
   - cargo doc
 after_success:
   - sh scripts/upload_doc.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,9 @@ branches:
     - master
     - auto
 script:
-  - cargo build -v
-  - cargo build -v --no-default-features
-  - cargo test -v
+  - cargo build -v --features strict
+  - cargo build -v --no-default-features --features strict
+  - cargo test -v --features strict
   - cargo doc
 after_success:
   - sh scripts/upload_doc.sh

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,10 @@ path = "src/lib.rs"
 
 [features]
 default = ["rustc_json_body", "ssl", "multipart"]
-benchmark = []
 rustc_json_body = ["rustc-serialize"]
 ssl = ["hyper/ssl"]
+
+benchmark = []
 strict = []
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ default = ["rustc_json_body", "ssl", "multipart"]
 benchmark = []
 rustc_json_body = ["rustc-serialize"]
 ssl = ["hyper/ssl"]
+strict = []
 
 [dependencies]
 time = "0.1"

--- a/README.md
+++ b/README.md
@@ -143,3 +143,9 @@ and it's not nice to see warnings from your dependencies when you are
 compiling your project, right? It's therefore recommend that you run your own
 tests with the `strict` feature enabled before pushing, just to see if you
 missed something.
+
+User facing Cargo features are tested one at the time, using
+`scripts/test_features.sh`, so any newly new user facing feature should be
+added to its feature list (as well as the list in this README). Development
+features, such as `strict`, or features that only exists as dependencies for
+other features does not count as user facing.

--- a/README.md
+++ b/README.md
@@ -135,3 +135,11 @@ is a small list of useful commands:
  * `cargo build --no-default-features` - Check if the most minimal version of Rustful builds.
  * `cargo build --no-default-features --features "feature1 feature2"` - Check if Rustful with only `feature1` and `feature2` enabled builds.
  * `cargo run --example example_name` - check if the example `example_name` behaves as expected (see the `example` directory).
+
+Travis and AppVeyor will run the tests with the `strict` feature enabled. This
+turns warnings and missing documentation into compile errors, which may be
+harsh, but it's for the sake of the user. Everything should have a description
+and it's not nice to see warnings from your dependencies when you are
+compiling your project, right? It's therefore recommend that you run your own
+tests with the `strict` feature enabled before pushing, just to see if you
+missed something.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,6 +22,6 @@ install:
   - cmd: SET OPENSSL_INCLUDE_DIR=C:\OpenSSL-Win32\include
 build: false
 test_script:
-  - cargo build -v
-  - cargo build -v --no-default-features
-  - cargo test --lib -v
+  - cargo build -v --features strict
+  - cargo build -v --no-default-features --features strict
+  - cargo test --lib -v --features strict

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,5 +23,5 @@ install:
 build: false
 test_script:
   - cargo build -v --features strict
-  - cargo build -v --no-default-features --features strict
   - cargo test --lib -v --features strict
+  - bash scripts\test_features.sh

--- a/scripts/test_features.sh
+++ b/scripts/test_features.sh
@@ -1,0 +1,14 @@
+#List of features to test
+FEATURES="
+	rustc_json_body
+	ssl
+	multipart
+"
+
+echo compiling with --no-default-features --features strict
+cargo build --no-default-features --features strict
+
+for FEATURE in $FEATURES; do
+	echo compiling with --no-default-features --features "\"$FEATURE strict\""
+	cargo build --no-default-features --features "$FEATURE strict"
+done

--- a/scripts/upload_doc.sh
+++ b/scripts/upload_doc.sh
@@ -1,3 +1,3 @@
-if [ "$TRAVIS_RUST_VERSION" != "nightly" ]; then
+if [ "$TRAVIS_RUST_VERSION" = "stable" ]; then
 	curl https://raw.githubusercontent.com/ogeon/travis-doc-upload/master/travis-doc-upload.sh | sh
 fi

--- a/src/file.rs
+++ b/src/file.rs
@@ -63,6 +63,7 @@ pub struct Loader {
 }
 
 impl Loader {
+    ///Create a new `Loader` with a buffer size of 1048576 bytes (1 megabyte).
     pub fn new() -> Loader {
         Loader {
             buffer_size: 1048576
@@ -118,6 +119,7 @@ pub enum Error<'a, 'b> {
 }
 
 impl<'a, 'b> Error<'a, 'b> {
+    ///Borrow the inner IO error.
     pub fn io_error(&self) -> &io::Error {
         match *self {
             Error::Open(ref e, _) => e,

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -40,15 +40,17 @@ pub enum ContextAction {
     ///Continue to the next filter in the stack.
     Next,
 
-    ///Abort and send HTTP status.
+    ///Abort and set HTTP status.
     Abort(StatusCode)
 }
 
 impl<'a> ContextAction {
+    ///Continue to the next filter in the stack.
     pub fn next() -> ContextAction {
         ContextAction::Next
     }
 
+    ///Abort and set HTTP status.
     pub fn abort(status: StatusCode) -> ContextAction {
         ContextAction::Abort(status)
     }
@@ -84,14 +86,17 @@ pub enum ResponseAction<'a> {
 }
 
 impl<'a> ResponseAction<'a> {
+    ///Continue to the next filter and maybe write data.
     pub fn next<T: Into<Data<'a>>>(data: Option<T>) -> ResponseAction<'a> {
         ResponseAction::Next(data.map(|d| d.into()))
     }
 
+    ///Do not continue to the next filter.
     pub fn silent_abort() -> ResponseAction<'a> {
         ResponseAction::SilentAbort
     }
 
+    ///Abort with an error.
     pub fn abort(message: String) -> ResponseAction<'a> {
         ResponseAction::Abort(message)
     }

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -5,6 +5,8 @@ use response::Response;
 
 ///A trait for request handlers.
 pub trait Handler: Send + Sync + 'static {
+    ///Handle a request from the client. Panicking within this method is
+    ///discouraged, to allow the server to run smoothly.
     fn handle_request(&self, context: Context, response: Response);
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,69 @@
+//!A light HTTP framework with REST-like features. The main purpose of Rustful
+//!is to create a simple, modular and non-intrusive foundation for HTTP
+//!applications. It has a mainly stateless structure, which naturally allows
+//!it to run both as one single server and as multiple instances in a cluster.
+//!
+//!A new server is created using the [`Server`][server] type, which contains
+//!all the necessary settings as fields:
+//!
+//!```no_run
+//!#[macro_use]
+//!extern crate rustful;
+//!use rustful::{Server, Handler, Context, Response, TreeRouter};
+//!
+//!struct Greeting(&'static str);
+//!
+//!impl Handler for Greeting {
+//!    fn handle_request(&self, context: Context, response: Response) {
+//!        //Check if the client accessed /hello/:name or /good_bye/:name
+//!        if let Some(name) = context.variables.get("name") {
+//!            //Use the value of :name
+//!            response.send(format!("{}, {}", self.0, name));
+//!        } else {
+//!            response.send(self.0)
+//!        }
+//!    }
+//!}
+//!
+//!# fn main() {
+//!let my_router = insert_routes!{
+//!    //Create a new TreeRouter
+//!    TreeRouter::new() => {
+//!        //Receive GET requests to /hello and /hello/:name
+//!        "hello" => {
+//!            Get: Greeting("hello"),
+//!            ":name" => Get: Greeting("hello")
+//!        },
+//!        //Receive GET requests to /good_bye and /good_bye/:name
+//!        "good_bye" => {
+//!            Get: Greeting("good bye"),
+//!            ":name" => Get: Greeting("good bye")
+//!        }
+//!    }
+//!};
+//!
+//!Server {
+//!    //Use a closure to handle requests.
+//!    handlers: my_router,
+//!    //Set the listening port to `8080`.
+//!    host: 8080.into(),
+//!    //Fill out everything else with default values.
+//!    ..Server::default()
+//!}.run();
+//!# }
+//!```
+//!
+//![server]: server/struct.Server.html
+
 #![crate_name = "rustful"]
 
 #![crate_type = "rlib"]
 
 #![doc(html_root_url = "http://ogeon.github.io/docs/rustful/master/")]
 
-#![cfg_attr(test, cfg_attr(feature = "benchmark", feature(test)))]
+#![cfg_attr(all(test, feature = "benchmark"), feature(test))]
+#![cfg_attr(feature = "strict", deny(missing_docs))]
+#![cfg_attr(feature = "strict", deny(warnings))]
 
 #[cfg(test)]
 #[cfg(feature = "benchmark")]

--- a/src/log.rs
+++ b/src/log.rs
@@ -4,6 +4,7 @@ use std::io::{self, Write};
 use std::fs;
 use std::sync::Mutex;
 
+///The result from a call to any of the `try_*` methods in `Log`.
 pub type Result = io::Result<()>;
 
 ///Common trait for log tools.
@@ -78,6 +79,7 @@ pub struct File {
 }
 
 impl File {
+    ///Create a new `File` logger with `file` as output destination.
     pub fn new(file: fs::File) -> File {
         File {
             file: Mutex::new(file)

--- a/src/response.rs
+++ b/src/response.rs
@@ -176,6 +176,8 @@ pub struct Response<'a, 'b> {
 }
 
 impl<'a, 'b> Response<'a, 'b> {
+    #[doc(hidden)]
+    ///Internal and may change without warning.
     pub fn new(
         response: hyper::server::response::Response<'a>,
         filters: &'b Vec<Box<ResponseFilter>>,

--- a/src/router/mod.rs
+++ b/src/router/mod.rs
@@ -120,6 +120,7 @@ impl<'a, T> From<Option<&'a T>> for Endpoint<'a, T> {
 ///A router must to implement this trait to be usable in a Rustful server. This
 ///trait will also make the router compatible with the `insert_routes!` macro.
 pub trait Router: Send + Sync + 'static {
+    ///The request handler type that is stored within this router.
     type Handler: Handler;
 
     ///Insert a new handler into the router.
@@ -141,6 +142,7 @@ impl<H: Handler> Router for H {
 
 ///A segmented route.
 pub trait Route<'a> {
+    ///An iterator over route segments.
     type Segments: Iterator<Item=&'a str>;
 
     ///Create a route segment iterator. The iterator is expected to return

--- a/src/router/tree_router.rs
+++ b/src/router/tree_router.rs
@@ -363,19 +363,19 @@ mod test {
 
     pub use self::LinkType::{SelfLink, ForwardLink};
 
-    fn check_variable(mut result: Endpoint<TestHandler>, expected: Option<&str>) {
+    fn check_variable(result: Endpoint<TestHandler>, expected: Option<&[&str]>) {
         assert_eq!(result.handler.is_some(), expected.is_some());
 
         if let Some(expected) = expected {
             let keys = vec!("a", "b", "c");
             let result = keys.into_iter().filter_map(|key| {
-                match result.variables.remove(key) {
-                    Some(value) => Some(value),
+                match result.variables.get(key) {
+                    Some(value) => Some(&**value),
                     None => None
                 }
-            }).collect::<Vec<String>>().connect(", ");
+            }).collect::<Vec<&str>>();
 
-            assert_eq!(&result, expected);
+            assert_eq!(&result[..], expected);
         } else {
             assert!(result.variables.len() == 0);
         }
@@ -441,7 +441,7 @@ mod test {
         let mut router = routes.into_iter().collect::<TreeRouter<_>>();
         router.find_hyperlinks = true;
 
-        check_variable(router.find(&Get, "path/to/test1"), Some("to"));
+        check_variable(router.find(&Get, "path/to/test1"), Some(&["to"]));
         check_variable(router.find(&Get, "path/to"), None);
         check_variable(router.find(&Get, "path/to/test1/nothing"), None);
     }
@@ -458,10 +458,10 @@ mod test {
         let mut router = routes.into_iter().collect::<TreeRouter<_>>();
         router.find_hyperlinks = true;
 
-        check_variable(router.find(&Get, "path/to/test1"), Some(""));
-        check_variable(router.find(&Get, "path/to/test/no2"), Some("to"));
-        check_variable(router.find(&Get, "path/to/test1/no/test3"), Some("test3, test1, no"));
-        check_variable(router.find(&Post, "path/to/test1/no/test3"), Some("no, test3, test1"));
+        check_variable(router.find(&Get, "path/to/test1"), Some(&[]));
+        check_variable(router.find(&Get, "path/to/test/no2"), Some(&["to"]));
+        check_variable(router.find(&Get, "path/to/test1/no/test3"), Some(&["test3", "test1", "no"]));
+        check_variable(router.find(&Post, "path/to/test1/no/test3"), Some(&["no", "test3", "test1"]));
         check_variable(router.find(&Get, "path/to/test1/no"), None);
     }
 
@@ -631,8 +631,8 @@ mod test {
 
         router1.insert_router(":a", router2);
         
-        check_variable(router1.find(&Get, "path/to/test1"), Some("path, to, test1"));
-        check_variable(router1.find(&Get, "path/to/test1/test"), Some("path, to, test1"));
+        check_variable(router1.find(&Get, "path/to/test1"), Some(&["path", "to", "test1"]));
+        check_variable(router1.find(&Get, "path/to/test1/test"), Some(&["path", "to", "test1"]));
     }
 
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -162,6 +162,7 @@ impl<R: Router> Server<R> {
         }
     }
 
+    ///Start the server.
     #[cfg(not(feature = "ssl"))]
     pub fn run(self) -> HttpResult<Listening> {
         let threads = self.threads;


### PR DESCRIPTION
This PR will make testing stricter to make sure we don't forget any documentation or let any warnings slip through. It will more precisely:

 * Make Travis test on stable, beta and nightly Rust, abandoning the tradition of keeping the tested version as low as possible. It seems like most dependencies does this, so we can't guarantee any backwards compatibility anyway, unless we completely freeze their versions.
 * Forbid missing documentation when testing on Travis and AppVeyor, and document previously undocumented parts.
 * Forbid warnings when testing on Travis and AppVeyor.
 * Add `strict` feature that is used to test with forbidden warnings and missing docs.
 * Add a script for compiling with one feature enabled at the time.