### PR TITLE
Move file sending code to Response

### DIFF
--- a/examples/handler_storage.rs
+++ b/examples/handler_storage.rs
@@ -15,7 +15,7 @@ use rustful::{
     TreeRouter,
     StatusCode
 };
-use rustful::file::{self, Loader};
+use rustful::response::FileError;
 
 fn main() {
     println!("Visit http://localhost:8080 to try this example.");
@@ -105,10 +105,10 @@ impl Handler for Api {
                 if let Some(file) = context.variables.get("file") {
                     //Make a full path from the file name and send it
                     let path = format!("examples/handler_storage/{}", file);
-                    let res = Loader::new().send_file(&path, response);
+                    let res = response.send_file(&path);
 
                     //Check if file could be opened
-                    if let Err(file::Error::Open(e, mut response)) = res {
+                    if let Err(FileError::Open(e, mut response)) = res {
                         if let io::ErrorKind::NotFound = e.kind() {
                             response.set_status(StatusCode::NotFound);
                         } else {

--- a/examples/handler_storage.rs
+++ b/examples/handler_storage.rs
@@ -78,7 +78,7 @@ fn read_string<P: AsRef<Path>>(path: P) -> io::Result<String> {
 
 enum Api {
     Counter {
-        //We are using the handler to preload the page in this exmaple
+        //We are using the handler to preload the page in this example
         page: Arc<String>,
 
         value: Arc<RwLock<i32>>,
@@ -105,17 +105,13 @@ impl Handler for Api {
                 if let Some(file) = context.variables.get("file") {
                     //Make a full path from the file name and send it
                     let path = format!("examples/handler_storage/{}", file);
-                    let res = response.send_file(&path);
+                    let res = response.send_file(&path).or_else(|e| e.send_not_found("the file was not found"));
 
-                    //Check if file could be opened
+                    //Check if a more fatal file error than "not found" occurred
                     if let Err(FileError::Open(e, mut response)) = res {
-                        if let io::ErrorKind::NotFound = e.kind() {
-                            response.set_status(StatusCode::NotFound);
-                        } else {
-                            //Something went horribly wrong
-                            context.log.error(&format!("failed to open '{}': {}", file, e.description()));
-                            response.set_status(StatusCode::InternalServerError);
-                        }
+                        //Something went horribly wrong
+                        context.log.error(&format!("failed to open '{}': {}", file, e.description()));
+                        response.set_status(StatusCode::InternalServerError);
                     }
                 } else {
                     //No file name was specified

--- a/src/file.rs
+++ b/src/file.rs
@@ -1,12 +1,6 @@
 //!File related utilities.
 
-use std::io::{self, Read};
-use std::fs::File;
-use std::path::Path;
-
-use response::Response;
 use mime::{Mime, TopLevel, SubLevel};
-use header::ContentType;
 
 include!(concat!(env!("OUT_DIR"), "/mime.rs"));
 
@@ -51,80 +45,6 @@ impl<'a> Into<SubLevel> for &'a MaybeKnown<SubLevel> {
         match *self {
             MaybeKnown::Known(ref s) => s.clone(),
             MaybeKnown::Unknown(s) => SubLevel::Ext(s.into())
-        }
-    }
-}
-
-///A utility for loading files from the file system and sending them to the
-///client.
-pub struct Loader {
-    ///The size, in bytes, of the file chunks. Default is 1048576 (1 megabyte).
-    pub buffer_size: usize
-}
-
-impl Loader {
-    ///Create a new `Loader` with a buffer size of 1048576 bytes (1 megabyte).
-    pub fn new() -> Loader {
-        Loader {
-            buffer_size: 1048576
-        }
-    }
-
-    ///Send a file to the client.
-    ///
-    ///A MIME type is automatically applied to the response, based on the file
-    ///extension, and `application/octet-stream` is used as a fallback if the
-    ///extension is unknown. See [`ext_to_mime`](fn.ext_to_mime.html) for more
-    ///information.
-    pub fn send_file<'a, 'b, P: AsRef<Path>>(&self, path: P, mut response: Response<'a, 'b>) -> Result<(), Error<'a, 'b>> {
-        let path: &Path = path.as_ref();
-        let mime = path
-            .extension()
-            .and_then(|ext| ext_to_mime(&ext.to_string_lossy()))
-            .unwrap_or(Mime(TopLevel::Application, SubLevel::Ext("octet-stream".into()), vec![]));
-
-        let mut file = match File::open(path) {
-            Ok(file) => file,
-            Err(e) => return Err(Error::Open(e, response))
-        };
-        let metadata = match file.metadata() {
-            Ok(metadata) => metadata,
-            Err(e) => return Err(Error::Open(e, response))
-        };
-
-        response.headers_mut().set(ContentType(mime));
-
-        let mut writer = unsafe { response.into_raw(metadata.len()) };
-        let mut buffer = vec![0; self.buffer_size];
-        loop {
-            match file.read(&mut buffer) {
-                Ok(len) if len == 0 => break,
-                Ok(len) => try!(writer.try_send(&buffer[..len]).map_err(|e| Error::Transfer(e))),
-                Err(e) => return Err(Error::Read(e))
-            }
-        }
-
-        Ok(())
-    }
-}
-
-///Error types from `Loader`.
-pub enum Error<'a, 'b> {
-    ///Failed to open the file.
-    Open(io::Error, Response<'a, 'b>),
-    ///Failed while reading the file.
-    Read(io::Error),
-    ///Failed while trasferring the file.
-    Transfer(io::Error)
-}
-
-impl<'a, 'b> Error<'a, 'b> {
-    ///Borrow the inner IO error.
-    pub fn io_error(&self) -> &io::Error {
-        match *self {
-            Error::Open(ref e, _) => e,
-            Error::Read(ref e) => e,
-            Error::Transfer(ref e) => e
         }
     }
 }


### PR DESCRIPTION
This moves the code for sending static files from the `file` module to `Response`. It's now more accessible, allows custom MIME types and the error type comes with a method for sending a 404 response if the file wasn't found.

This will break anything that uses `rustful::file::Loader` or `rustful::file::Error`.