### PR TITLE
Automatically gather the features to be tested

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ branches:
 script:
   - cargo build -v --features strict
   - cargo test -v --features strict
-  - sh scripts/test_features.sh
+  - bash scripts/test_features.sh
   - cargo doc
 after_success:
   - sh scripts/upload_doc.sh

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ default = ["rustc_json_body", "ssl", "multipart"]
 rustc_json_body = ["rustc-serialize"]
 ssl = ["hyper/ssl"]
 
+#internal
 benchmark = []
 strict = []
 
@@ -34,6 +35,7 @@ version = "0.6"
 default-features = false
 
 [dependencies.multipart]
+#feature
 version = "0.3"
 default-features = false
 features = ["server"]

--- a/README.md
+++ b/README.md
@@ -144,8 +144,38 @@ compiling your project, right? It's therefore recommend that you run your own
 tests with the `strict` feature enabled before pushing, just to see if you
 missed something.
 
-User facing Cargo features are tested one at the time, using
-`scripts/test_features.sh`, so any newly new user facing feature should be
-added to its feature list (as well as the list in this README). Development
-features, such as `strict`, or features that only exists as dependencies for
-other features does not count as user facing.
+###Automatic Feature Testing
+
+User facing Cargo features are automatically gathered from `Cargo.toml` and
+tested one at the time, using `scripts/test_features.sh`. The lack of public
+and private features forces us to use a special annotation to differ between
+internal and user facing feature. Here is an simple example snippet of how the
+`Cargo.toml` is expected to look:
+
+```toml
+#...
+
+[features]
+default = ["feature_a", "feature_b"]
+feature_a = ["feature_c"]
+feature_b = []
+
+#internal
+feature_c = []
+
+[dependencies.optional_lib]
+#feature
+optional=true
+
+#...
+```
+
+Features that are supposed to be available to the user has to be declared
+before the `#internal` comment. This will tell the test script that these are
+supposed to be tested.
+
+Dependency libraries can also be features, so we have to annotate these as
+well. Each dependency that is supposed to work as a user facing feature will
+need a `#feature` comment somewhere within its declaration. This will only
+work with features that are declared using the above form, and not the
+`feature_lib = { ... }` form.

--- a/scripts/test_features.sh
+++ b/scripts/test_features.sh
@@ -1,14 +1,42 @@
 #List of features to test
-FEATURES="
-	rustc_json_body
-	ssl
-	multipart
-"
+features=""
 
-echo compiling with --no-default-features --features strict
-cargo build --no-default-features --features strict
+#Features that will always be activated
+required_features="strict"
 
-for FEATURE in $FEATURES; do
-	echo compiling with --no-default-features --features "\"$FEATURE strict\""
-	cargo build --no-default-features --features "$FEATURE strict"
+
+#Find features
+walking_features=false
+current_dependency=""
+
+while read -r line || [[ -n "$line" ]]; do
+	if [[ "$line" == "[features]" ]]; then
+		walking_features=true
+	elif [[ $walking_features == true ]] && [[ "$line" == "#internal" ]]; then
+		walking_features=false
+	elif [[ $walking_features == true ]] && echo "$line" | grep -E "^\[.*\]" > /dev/null; then
+		walking_features=false
+	elif [[ $walking_features == true ]] && echo "$line" | grep -E ".*=.*" > /dev/null; then
+		feature="$(echo "$line" | cut -f1 -d"=")"
+		feature="$(echo -e "${feature}" | tr -d '[[:space:]]')"
+		if [[ "$feature" != "default" ]]; then
+			echo "found feature '$feature'"
+			features="$features $feature"
+		fi
+	elif echo "$line" | grep -E "^\[dependencies\..*\]" > /dev/null; then
+		current_dependency="$(echo "$line" | sed 's/.*\[dependencies\.\([^]]*\)\].*/\1/g')"
+	elif [[ "$line" == "#feature" ]] && [[ "$current_dependency" != "" ]]; then
+		echo "found dependency feature '$current_dependency'"
+		features="$features $current_dependency"
+	fi
+done < "Cargo.toml"
+
+#Test without any optional feature
+echo compiling with --no-default-features --features "$required_features"
+cargo build --no-default-features --features "$required_features"
+
+#Isolated test of each optional feature
+for feature in $features; do
+	echo compiling with --no-default-features --features "\"$feature $required_features\""
+	cargo build --no-default-features --features "$feature $required_features"
 done


### PR DESCRIPTION
This modifies the feature test script to automatically gather the features, instead of requiring the developer to remember to add new features to its list.

Disclaimer: I'm not a Bash wizard, so it may seem clunky, but it works.