### PR TITLE
Force connections to close if the thread pool is too congested

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ time = "0.1"
 url = "0.2"
 anymap = "0.11"
 phf = "0.7"
+num_cpus = "0.2"
 
 [dependencies.hyper]
 version = "0.6"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,6 +83,7 @@ extern crate time;
 extern crate hyper;
 extern crate anymap;
 extern crate phf;
+extern crate num_cpus;
 
 pub use hyper::mime;
 pub use hyper::method::Method;


### PR DESCRIPTION
This adds a counter in the server that counts the number of open connections, and lets the user decide how many threads has to be available for new connections. The server will force new connections to close if the number of available threads are as many as the user defined amount, or less.

Closes #65