### PR TITLE
Remove ICE hacks and set the oldest tested Rust version to 1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ extern crate rustful;
 
 use std::error::Error;
 
-use rustful::{Server, Context, Response, TreeRouter, Handler};
+use rustful::{Server, Context, Response, TreeRouter};
 
 fn say_hello(context: Context, response: Response) {
     //Get the value of the path variable `:person`, from below.
@@ -70,15 +70,6 @@ fn say_hello(context: Context, response: Response) {
     response.send(format!("Hello, {}!", person));
 }
 
-//Dodge an ICE, related to functions as handlers.
-struct HandlerFn(fn(Context, Response));
-
-impl Handler for HandlerFn {
-    fn handle_request(&self, context: Context, response: Response) {
-        self.0(context, response);
-    }
-}
-
 fn main() {
     //Build and run the server.
     let server_result = Server {
@@ -89,11 +80,11 @@ fn main() {
         handlers: insert_routes!{
             TreeRouter::new() => {
                 //Handle requests for root...
-                Get: HandlerFn(say_hello),
+                Get: say_hello,
 
                 //...and one level below.
                 //`:person` is a path variable and it will be accessible in the handler.
-                ":person" => Get: HandlerFn(say_hello)
+                ":person" => Get: say_hello
             }
         },
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,7 @@ os: MinGW
 environment:
   RUST_INSTALL_DIR: C:\Rust
   RUST_INSTALL_TRIPLE: i686-pc-windows-gnu
-  RUST_VERSION: 1.1.0
+  RUST_VERSION: 1.3.0
   OPENSSL_VERSION: 1_0_2d
 install:
   - ps: Start-FileDownload "https://static.rust-lang.org/dist/rust-$Env:RUST_VERSION-$Env:RUST_INSTALL_TRIPLE.exe"

--- a/examples/filters.rs
+++ b/examples/filters.rs
@@ -4,7 +4,7 @@ extern crate rustful;
 use std::sync::RwLock;
 use std::error::Error;
 
-use rustful::{Server, TreeRouter, Context, Response, Log, Handler};
+use rustful::{Server, TreeRouter, Context, Response, Log};
 use rustful::filter::{FilterContext, ResponseFilter, ResponseAction, ContextFilter, ContextAction};
 use rustful::response::Data;
 use rustful::StatusCode;
@@ -49,10 +49,9 @@ enum Format {
     Text
 }
 
-//Dodge an ICE, related to functions as handlers.
-struct HandlerFn(fn(Context, Response, &Format), Format);
+struct Handler(fn(Context, Response, &Format), Format);
 
-impl Handler for HandlerFn {
+impl rustful::Handler for Handler {
     fn handle_request(&self, context: Context, response: Response) {
         self.0(context, response, &self.1);
     }
@@ -66,12 +65,12 @@ fn main() {
     insert_routes!{
         &mut router => {
             "print" => {
-                Get: HandlerFn(say_hello, Format::Text),
-                ":person" => Get: HandlerFn(say_hello, Format::Text),
+                Get: Handler(say_hello, Format::Text),
+                ":person" => Get: Handler(say_hello, Format::Text),
 
                 "json" => {
-                    Get: HandlerFn(say_hello, Format::Json),
-                    ":person" => Get: HandlerFn(say_hello, Format::Json)
+                    Get: Handler(say_hello, Format::Json),
+                    ":person" => Get: Handler(say_hello, Format::Json)
                 }
             }
         }

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -4,7 +4,7 @@ extern crate rustful;
 
 use std::error::Error;
 
-use rustful::{Server, Context, Response, TreeRouter, Handler};
+use rustful::{Server, Context, Response, TreeRouter};
 
 fn say_hello(context: Context, response: Response) {
     //Get the value of the path variable `:person`, from below.
@@ -15,15 +15,6 @@ fn say_hello(context: Context, response: Response) {
 
     //Use the name from the path variable to say hello.
     response.send(format!("Hello, {}!", person));
-}
-
-//Dodge an ICE, related to functions as handlers.
-struct HandlerFn(fn(Context, Response));
-
-impl Handler for HandlerFn {
-    fn handle_request(&self, context: Context, response: Response) {
-        self.0(context, response);
-    }
 }
 
 fn main() {
@@ -38,11 +29,11 @@ fn main() {
         handlers: insert_routes!{
             TreeRouter::new() => {
                 //Handle requests for root...
-                Get: HandlerFn(say_hello),
+                Get: say_hello,
 
                 //...and one level below.
                 //`:person` is a path variable and it will be accessible in the handler.
-                ":person" => Get: HandlerFn(say_hello)
+                ":person" => Get: say_hello
             }
         },
 

--- a/examples/post.rs
+++ b/examples/post.rs
@@ -7,7 +7,7 @@ use std::path::Path;
 use std::borrow::Cow;
 use std::error::Error;
 
-use rustful::{Server, Context, Response, Log, Handler};
+use rustful::{Server, Context, Response, Log};
 use rustful::context::body::ExtQueryBody;
 use rustful::StatusCode::{InternalServerError, BadRequest};
 
@@ -42,15 +42,6 @@ fn say_hello(mut context: Context, mut response: Response) {
     response.send(complete_page);
 }
 
-//Dodge an ICE, related to functions as handlers.
-struct HandlerFn(fn(Context, Response));
-
-impl Handler for HandlerFn {
-    fn handle_request(&self, context: Context, response: Response) {
-        self.0(context, response);
-    }
-}
-
 fn main() {
     println!("Visit http://localhost:8080 to try this example.");
 
@@ -65,7 +56,7 @@ fn main() {
         host: 8080.into(),
         global: Box::new(files).into(),
         content_type: content_type!(Text / Html; Charset = Utf8),
-        ..Server::new(HandlerFn(say_hello))
+        ..Server::new(say_hello)
     }.run();
 
     //Check if the server started successfully


### PR DESCRIPTION
This removes all the hacky wrapper structs that was added to make the examples of handler functions compile in pre 1.3 Rust (I think I got them all). This will also change the AppVeyor test script to use Rust 1.3, since it's now the oldest recommended version.

Closes #17