### PR TITLE
Get rid of some of the rough edges regarding MaybeUtf8

### DIFF
--- a/src/context/maybe_utf8.rs
+++ b/src/context/maybe_utf8.rs
@@ -1,4 +1,4 @@
-use std::ops::Deref;
+use std::ops::{Deref, DerefMut, Drop};
 use std::borrow::{Cow, Borrow};
 use std::hash::{Hash, Hasher};
 
@@ -19,7 +19,19 @@ pub enum MaybeUtf8<S, V> {
 }
 
 impl<S, V> MaybeUtf8<S, V> {
+    ///Create an empty UTF-8 string.
+    pub fn new() -> MaybeUtf8<S, V> where S: From<&'static str> {
+        MaybeUtf8::Utf8("".into())
+    }
+
     ///Produce a slice of this string.
+    ///
+    ///```
+    ///use rustful::context::{MaybeUtf8Owned, MaybeUtf8Slice};
+    ///
+    ///let owned = MaybeUtf8Owned::from("abc");
+    ///let slice: MaybeUtf8Slice = owned.as_slice();
+    ///```
     pub fn as_slice<Sref: ?Sized, Vref: ?Sized>(&self) -> MaybeUtf8<&Sref, &Vref> where S: AsRef<Sref>, V: AsRef<Vref> {
         match *self {
             MaybeUtf8::Utf8(ref s) => MaybeUtf8::Utf8(s.as_ref()),
@@ -28,6 +40,13 @@ impl<S, V> MaybeUtf8<S, V> {
     }
 
     ///Borrow the string if it's encoded as valid UTF-8.
+    ///
+    ///```
+    ///use rustful::context::MaybeUtf8Owned;
+    ///
+    ///let string = MaybeUtf8Owned::from("abc");
+    ///assert_eq!(Some("abc"), string.as_utf8());
+    ///```
     pub fn as_utf8<'a>(&'a self) -> Option<&'a str> where S: AsRef<str> {
         match *self {
             MaybeUtf8::Utf8(ref s) => Some(s.as_ref()),
@@ -36,6 +55,13 @@ impl<S, V> MaybeUtf8<S, V> {
     }
 
     ///Borrow the string if it's encoded as valid UTF-8, or make a lossy conversion.
+    ///
+    ///```
+    ///use rustful::context::MaybeUtf8Owned;
+    ///
+    ///let string = MaybeUtf8Owned::from("abc");
+    ///assert_eq!("abc", string.as_utf8_lossy());
+    ///```
     pub fn as_utf8_lossy<'a>(&'a self) -> Cow<'a, str> where S: AsRef<str>, V: AsRef<[u8]> {
         match *self {
             MaybeUtf8::Utf8(ref s) => s.as_ref().into(),
@@ -44,16 +70,49 @@ impl<S, V> MaybeUtf8<S, V> {
     }
 
     ///Borrow the string as a slice of bytes.
+    ///
+    ///```
+    ///use rustful::context::MaybeUtf8Owned;
+    ///
+    ///let string = MaybeUtf8Owned::from("abc");
+    ///assert_eq!(b"abc", string.as_bytes());
+    ///```
     pub fn as_bytes(&self) -> &[u8] where S: AsRef<[u8]>, V: AsRef<[u8]> {
         match *self {
             MaybeUtf8::Utf8(ref s) => s.as_ref(),
             MaybeUtf8::NotUtf8(ref v) => v.as_ref()
         }
     }
+
+    ///Check if the string is valid UTF-8.
+    ///
+    ///```
+    ///use rustful::context::MaybeUtf8Owned;
+    ///
+    ///let valid = MaybeUtf8Owned::from("abc");
+    ///assert_eq!(valid.is_utf8(), true);
+    ///
+    ///let invalid = MaybeUtf8Owned::from(vec![255]);
+    ///assert_eq!(invalid.is_utf8(), false);
+    ///```
+    pub fn is_utf8(&self) -> bool {
+        match *self {
+            MaybeUtf8::Utf8(_) => true,
+            MaybeUtf8::NotUtf8(_) => false
+        }
+    }
 }
 
 impl MaybeUtf8<String, Vec<u8>> {
     ///Push a single `char` to the end of the string.
+    ///
+    ///```
+    ///use rustful::context::MaybeUtf8Owned;
+    ///
+    ///let mut string = MaybeUtf8Owned::from("abc");
+    ///string.push_char('d');
+    ///assert_eq!("abcd", string);
+    ///```
     pub fn push_char(&mut self, c: char) {
         match *self {
             MaybeUtf8::Utf8(ref mut s) => s.push(c),
@@ -65,7 +124,30 @@ impl MaybeUtf8<String, Vec<u8>> {
         }
     }
 
+    ///Push a single byte to the end of the string. The string's UTF-8
+    ///compatibility will be reevaluated and may change each time `push_byte`
+    ///is called. This may have a noticeable performance impact.
+    ///
+    ///```
+    ///use rustful::context::MaybeUtf8Owned;
+    ///
+    ///let mut string = MaybeUtf8Owned::from("abc");
+    ///string.push_byte(255);
+    ///assert_eq!(string.is_utf8(), false);
+    ///```
+    pub fn push_byte(&mut self, byte: u8) {
+        self.push_bytes(&[byte])
+    }
+
     ///Extend the string.
+    ///
+    ///```
+    ///use rustful::context::MaybeUtf8Owned;
+    ///
+    ///let mut string = MaybeUtf8Owned::from("abc");
+    ///string.push_str("def");
+    ///assert_eq!("abcdef", string);
+    ///```
     pub fn push_str(&mut self, string: &str) {
         match *self {
             MaybeUtf8::Utf8(ref mut s) => s.push_str(string),
@@ -73,18 +155,33 @@ impl MaybeUtf8<String, Vec<u8>> {
         }
     }
 
-    ///Push a number of bytes to the string. The strings UTF-8 compatibility
+    ///Push a number of bytes to the string. The string's UTF-8 compatibility
     ///may change.
+    ///
+    ///```
+    ///use rustful::context::MaybeUtf8Owned;
+    ///
+    ///let mut string = MaybeUtf8Owned::from("abc");
+    ///string.push_bytes(&[100, 101, 102]);
+    ///assert_eq!("abcdef", string);
+    ///```
     pub fn push_bytes(&mut self, bytes: &[u8]) {
         match ::std::str::from_utf8(bytes) {
             Ok(string) => self.push_str(string),
             Err(_) => {
-                let mut v = MaybeUtf8::NotUtf8(vec![]);
-                ::std::mem::swap(self, &mut v);
-                let mut v: Vec<u8> = v.into();
-                v.push_bytes(bytes);
-                *self = v.into();
+                self.as_buffer().push_bytes(bytes);
             }
+        }
+    }
+
+    ///Borrow this string as a mutable byte buffer. The string's UTF-8
+    ///compatibility will be reevaluated when the buffer is dropped.
+    pub fn as_buffer(&mut self) -> Buffer {
+        let mut v = MaybeUtf8::NotUtf8(vec![]);
+        ::std::mem::swap(self, &mut v);
+        Buffer {
+            bytes: v.into(),
+            source: self
         }
     }
 }
@@ -95,9 +192,9 @@ impl<V> From<String> for MaybeUtf8<String, V> {
     }
 }
 
-impl<'a, V> From<&'a str> for MaybeUtf8<&'a str, V> {
-    fn from(string: &'a str) -> MaybeUtf8<&'a str, V> {
-        MaybeUtf8::Utf8(string)
+impl<'a, S: From<&'a str>, V> From<&'a str> for MaybeUtf8<S, V> {
+    fn from(string: &'a str) -> MaybeUtf8<S, V> {
+        MaybeUtf8::Utf8(string.into())
     }
 }
 
@@ -125,14 +222,76 @@ impl<S: AsRef<[u8]>, V: AsRef<[u8]>> Borrow<[u8]> for MaybeUtf8<S, V> {
     }
 }
 
-impl<S1, V1, S2, V2> PartialEq<MaybeUtf8<S1, V1>> for MaybeUtf8<S2, V2> where
-    S1: AsRef<[u8]>,
-    V1: AsRef<[u8]>,
-    S2: AsRef<[u8]>,
-    V2: AsRef<[u8]>
+impl<S, V, B: ?Sized> PartialEq<B> for MaybeUtf8<S, V> where
+    S: AsRef<[u8]>,
+    V: AsRef<[u8]>,
+    B: AsRef<[u8]>
 {
-    fn eq(&self, other: &MaybeUtf8<S1, V1>) -> bool {
+    fn eq(&self, other: &B) -> bool {
         self.as_ref().eq(other.as_ref())
+    }
+}
+
+impl<S, V> PartialEq<MaybeUtf8<S, V>> for str where
+    S: AsRef<[u8]>,
+    V: AsRef<[u8]>
+{
+    fn eq(&self, other: &MaybeUtf8<S, V>) -> bool {
+        other.eq(self)
+    }
+}
+
+impl<'a, S, V> PartialEq<MaybeUtf8<S, V>> for &'a str where
+    S: AsRef<[u8]>,
+    V: AsRef<[u8]>
+{
+    fn eq(&self, other: &MaybeUtf8<S, V>) -> bool {
+        other.eq(self)
+    }
+}
+
+impl<S, V> PartialEq<MaybeUtf8<S, V>> for String where
+    S: AsRef<[u8]>,
+    V: AsRef<[u8]>
+{
+    fn eq(&self, other: &MaybeUtf8<S, V>) -> bool {
+        other.eq(self)
+    }
+}
+
+impl<'a, S, V> PartialEq<MaybeUtf8<S, V>> for Cow<'a, str> where
+    S: AsRef<[u8]>,
+    V: AsRef<[u8]>
+{
+    fn eq(&self, other: &MaybeUtf8<S, V>) -> bool {
+        other.eq(self.as_ref())
+    }
+}
+
+impl<S, V> PartialEq<MaybeUtf8<S, V>> for [u8] where
+    S: AsRef<[u8]>,
+    V: AsRef<[u8]>
+{
+    fn eq(&self, other: &MaybeUtf8<S, V>) -> bool {
+        other.eq(self)
+    }
+}
+
+impl<'a, S, V> PartialEq<MaybeUtf8<S, V>> for &'a [u8] where
+    S: AsRef<[u8]>,
+    V: AsRef<[u8]>
+{
+    fn eq(&self, other: &MaybeUtf8<S, V>) -> bool {
+        other.eq(self)
+    }
+}
+
+impl<S, V> PartialEq<MaybeUtf8<S, V>> for Vec<u8> where
+    S: AsRef<[u8]>,
+    V: AsRef<[u8]>
+{
+    fn eq(&self, other: &MaybeUtf8<S, V>) -> bool {
+        other.eq(self)
     }
 }
 
@@ -173,5 +332,80 @@ impl<S: AsRef<[u8]>, V: AsRef<[u8]>> Deref for MaybeUtf8<S, V> {
 
     fn deref(&self) -> &[u8] {
         self.as_ref()
+    }
+}
+
+///A byte buffer for more efficient `MaybeUtf8` manipulation.
+///
+///The buffer is essentially a `&mut Vec<u8>` that will be checked for UTF-8
+///compatibility when dropped. It comes with a few extra convenience methods.
+pub struct Buffer<'a> {
+    bytes: Vec<u8>,
+    source: &'a mut MaybeUtf8<String, Vec<u8>>
+}
+
+impl<'a> Buffer<'a> {
+    ///Push a number of bytes to the buffer in a relatively efficient way.
+    ///
+    ///```
+    ///use rustful::context::MaybeUtf8Owned;
+    ///
+    ///let mut string = MaybeUtf8Owned::new();
+    ///
+    ///{
+    ///    let mut buffer = string.as_buffer();
+    ///    buffer.push_bytes("abc".as_bytes());
+    ///}
+    ///
+    ///assert!(string.is_utf8());
+    ///assert_eq!("abc", string);
+    ///```
+    pub fn push_bytes(&mut self, bytes: &[u8]) {
+        self.bytes.push_bytes(bytes)
+    }
+
+    ///Push a single `char` to the end of the buffer.
+    ///
+    ///```
+    ///use rustful::context::MaybeUtf8Owned;
+    ///
+    ///let mut string = MaybeUtf8Owned::new();
+    ///
+    ///{
+    ///    let mut buffer = string.as_buffer();
+    ///    buffer.push_char('å');
+    ///    buffer.push_char('1');
+    ///    buffer.push_char('€');
+    ///}
+    ///
+    ///assert!(string.is_utf8());
+    ///assert_eq!("å1€", string);
+    ///```
+    pub fn push_char(&mut self, c: char) {
+        //Do some witchcraft until encode_utf8 becomes a thing.
+        let string: &mut String = unsafe { ::std::mem::transmute(&mut self.bytes) };
+        string.push(c);
+    }
+}
+
+impl<'a> Deref for Buffer<'a> {
+    type Target = Vec<u8>;
+
+    fn deref(&self) -> &Vec<u8> {
+        &self.bytes
+    }
+}
+
+impl<'a> DerefMut for Buffer<'a> {
+    fn deref_mut(&mut self) -> &mut Vec<u8> {
+        &mut self.bytes
+    }
+}
+
+impl<'a> Drop for Buffer<'a> {
+    fn drop(&mut self) {
+        let mut v = vec![];
+        ::std::mem::swap(&mut v, &mut self.bytes);
+        *self.source = v.into();
     }
 }

--- a/src/context/maybe_utf8.rs
+++ b/src/context/maybe_utf8.rs
@@ -2,6 +2,8 @@ use std::ops::Deref;
 use std::borrow::{Cow, Borrow};
 use std::hash::{Hash, Hasher};
 
+use ::utils::BytesExt;
+
 ///An owned string that may be UTF-8 encoded.
 pub type MaybeUtf8Owned = MaybeUtf8<String, Vec<u8>>;
 ///A slice of a string that may be UTF-8 encoded.
@@ -67,7 +69,7 @@ impl MaybeUtf8<String, Vec<u8>> {
     pub fn push_str(&mut self, string: &str) {
         match *self {
             MaybeUtf8::Utf8(ref mut s) => s.push_str(string),
-            MaybeUtf8::NotUtf8(ref mut v) => v.extend(string.as_bytes().iter().cloned())
+            MaybeUtf8::NotUtf8(ref mut v) => v.push_bytes(string.as_bytes())
         }
     }
 
@@ -80,7 +82,7 @@ impl MaybeUtf8<String, Vec<u8>> {
                 let mut v = MaybeUtf8::NotUtf8(vec![]);
                 ::std::mem::swap(self, &mut v);
                 let mut v: Vec<u8> = v.into();
-                v.extend(bytes.iter().cloned());
+                v.push_bytes(bytes);
                 *self = v.into();
             }
         }

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -146,7 +146,7 @@ pub mod body;
 pub mod hypermedia;
 
 mod maybe_utf8;
-pub use self::maybe_utf8::{MaybeUtf8, MaybeUtf8Owned, MaybeUtf8Slice};
+pub use self::maybe_utf8::{MaybeUtf8, MaybeUtf8Owned, MaybeUtf8Slice, Buffer};
 
 mod parameters;
 pub use self::parameters::Parameters;

--- a/src/router/tree_router.rs
+++ b/src/router/tree_router.rs
@@ -6,7 +6,7 @@ use std::ops::Deref;
 use hyper::method::Method;
 
 use router::{Router, Route, Endpoint};
-use context::MaybeUtf8Owned;
+use context::{MaybeUtf8Owned, MaybeUtf8Slice};
 use context::hypermedia::{Link, LinkSegment, SegmentType};
 use handler::Handler;
 
@@ -279,7 +279,7 @@ impl<T: Handler> Router for TreeRouter<T> {
                         result.hypermedia.links.push(Link {
                             method: None,
                             path: vec![LinkSegment {
-                                label: "".into(),
+                                label: MaybeUtf8Slice::new(),
                                 ty: SegmentType::VariableSegment
                             }]
                         });
@@ -289,7 +289,7 @@ impl<T: Handler> Router for TreeRouter<T> {
                         result.hypermedia.links.push(Link {
                             method: None,
                             path: vec![LinkSegment {
-                                label: "".into(),
+                                label: MaybeUtf8Slice::new(),
                                 ty: SegmentType::VariableSequence
                             }]
                         });

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,3 +1,4 @@
+use std::io::Write;
 use url::percent_encoding::percent_decode;
 use context::Parameters;
 
@@ -25,6 +26,18 @@ pub fn parse_parameters(source: &[u8]) -> Parameters {
     }
 
     parameters
+}
+
+///Extension trait for byte vectors.
+pub trait BytesExt {
+    ///Copy a number of bytes to the vector.
+    fn push_bytes(&mut self, bytes: &[u8]);
+}
+
+impl BytesExt for Vec<u8> {
+    fn push_bytes(&mut self, bytes: &[u8]) {
+        self.write_all(bytes).unwrap();
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
 * Makes it easier to modify `MaybeUtf8<String, Vec<u8>>` as a byte vector, without completely converting it to `Vec<u8>`.
 * Makes it possible to compare it with more types.
 * Adds a few examples.