### PR TITLE
Implement Handler for Arc

### DIFF
--- a/src/handler.rs
+++ b/src/handler.rs
@@ -2,6 +2,7 @@
 
 use context::Context;
 use response::Response;
+use std::sync::Arc;
 
 ///A trait for request handlers.
 pub trait Handler: Send + Sync + 'static {
@@ -13,5 +14,17 @@ pub trait Handler: Send + Sync + 'static {
 impl<F: Fn(Context, Response) + Send + Sync + 'static> Handler for F {
     fn handle_request(&self, context: Context, response: Response) {
         self(context, response);
+    }
+}
+
+impl<T: Handler> Handler for Arc<T> {
+    fn handle_request(&self, context: Context, response: Response) {
+        (**self).handle_request(context, response);
+    }
+}
+
+impl Handler for Box<Handler> {
+    fn handle_request(&self, context: Context, response: Response) {
+        (**self).handle_request(context, response);
     }
 }


### PR DESCRIPTION
Implement Handler for Arc and Box

1. Handler trait impl for `Arc<T>` calls `handle_request()` on `T`.
2. Handler trait can not be implemented generically for `Box` without
conflicting with trait impl for `Fn()`. So implemented for `Box<Handler>`.
Clients need to cast their `Box<T>` as `Box<Handler>` to use this.

Fixes #70