### PR TITLE
Move hypermedia responsibility from router to handlers

### DIFF
--- a/examples/todo.rs
+++ b/examples/todo.rs
@@ -178,7 +178,7 @@ struct Api(Option<fn(&Database, Context, Response)>);
 impl Handler for Api {
     fn handle_request(&self, context: Context, mut response: Response) {
         //Collect the accepted methods from the provided hyperlinks
-        let mut methods: Vec<_> = context.hypermedia.links.iter().filter_map(|l| l.method.clone()).collect();
+        let mut methods: Vec<_> = context.hyperlinks.iter().filter_map(|l| l.method.clone()).collect();
         methods.push(context.method.clone());
 
         //Setup cross origin resource sharing

--- a/src/context/hypermedia.rs
+++ b/src/context/hypermedia.rs
@@ -5,22 +5,6 @@ use Method;
 use Handler;
 use context::MaybeUtf8Slice;
 
-///Hypermedia connected to an API endpoint.
-pub struct Hypermedia<'a> {
-    ///Forward links from the current endpoint to other endpoints. These may
-    ///include endpoints with the same path, but different method.
-    pub links: Vec<Link<'a>>
-}
-
-impl<'a> Hypermedia<'a> {
-    ///Create an empty `Hypermedia` structure.
-    pub fn new() -> Hypermedia<'a> {
-        Hypermedia {
-            links: vec![]
-        }
-    }
-}
-
 ///A hyperlink.
 pub struct Link<'a> {
     ///The HTTP method for which an endpoint is available. It can be left

--- a/src/context/hypermedia.rs
+++ b/src/context/hypermedia.rs
@@ -1,6 +1,8 @@
 //!Anything related to hypermedia and hyperlinks.
+use std::fmt;
 
 use Method;
+use Handler;
 use context::MaybeUtf8Slice;
 
 ///Hypermedia connected to an API endpoint.
@@ -20,13 +22,20 @@ impl<'a> Hypermedia<'a> {
 }
 
 ///A hyperlink.
-#[derive(PartialEq, Eq, Debug)]
 pub struct Link<'a> {
     ///The HTTP method for which an endpoint is available. It can be left
     ///unspecified if the method doesn't matter.
     pub method: Option<Method>,
     ///A relative path from the current location.
-    pub path: Vec<LinkSegment<'a>>
+    pub path: Vec<LinkSegment<'a>>,
+    ///The handler that will answer at the endpoint.
+    pub handler: Option<&'a Handler>,
+}
+
+impl<'a> fmt::Debug for Link<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "method: {:?}, path: {:?}, handler present: {}", self.method, self.path, self.handler.is_some())
+    }
 }
 
 ///A segment of a hyperlink path.

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -119,7 +119,7 @@ use header::Headers;
 use server::Global;
 
 use self::body::BodyReader;
-use self::hypermedia::Hypermedia;
+use self::hypermedia::Link;
 
 pub mod body;
 pub mod hypermedia;
@@ -147,8 +147,8 @@ pub struct Context<'a, 'b: 'a, 's> {
     ///The requested URI.
     pub uri: Uri,
 
-    ///Hypermedia from the current endpoint.
-    pub hypermedia: Hypermedia<'s>,
+    ///Hyperlinks from the current endpoint.
+    pub hyperlinks: Vec<Link<'s>>,
 
     ///Route variables.
     pub variables: Parameters,

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -1,4 +1,5 @@
 //!Request handlers.
+use std::borrow::Cow;
 
 use context::Context;
 use response::Response;
@@ -9,6 +10,11 @@ pub trait Handler: Send + Sync + 'static {
     ///Handle a request from the client. Panicking within this method is
     ///discouraged, to allow the server to run smoothly.
     fn handle_request(&self, context: Context, response: Response);
+
+    ///Get a description for the handler.
+    fn description(&self) -> Option<Cow<'static, str>> {
+        None
+    }
 }
 
 impl<F: Fn(Context, Response) + Send + Sync + 'static> Handler for F {

--- a/src/router/mod.rs
+++ b/src/router/mod.rs
@@ -88,7 +88,7 @@ use hyper::method::Method;
 
 use handler::Handler;
 use context::MaybeUtf8Owned;
-use context::hypermedia::Hypermedia;
+use context::hypermedia::Link;
 
 pub use self::tree_router::TreeRouter;
 
@@ -101,8 +101,8 @@ pub struct Endpoint<'a, T: 'a> {
     ///Path variables for the matching endpoint. May be empty, depending on
     ///the router implementation.
     pub variables: HashMap<MaybeUtf8Owned, MaybeUtf8Owned>,
-    ///Any associated hypermedia, such as links.
-    pub hypermedia: Hypermedia<'a>
+    ///Any associated hyperlinks.
+    pub hyperlinks: Vec<Link<'a>>
 }
 
 impl<'a, T> From<Option<&'a T>> for Endpoint<'a, T> {
@@ -110,7 +110,7 @@ impl<'a, T> From<Option<&'a T>> for Endpoint<'a, T> {
         Endpoint {
             handler: handler,
             variables: HashMap::new(),
-            hypermedia: Hypermedia::new()
+            hyperlinks: vec![]
         }
     }
 }

--- a/src/router/tree_router.rs
+++ b/src/router/tree_router.rs
@@ -258,7 +258,7 @@ impl<T: Handler> Router for TreeRouter<T> {
                 if branch == Static {
                     for (other_method, &(ref item, _)) in &current.items {
                         if other_method != method {
-                            result.hypermedia.links.push(Link {
+                            result.hyperlinks.push(Link {
                                 method: Some(other_method.clone()),
                                 path: vec![],
                                 handler: Some(item)
@@ -267,7 +267,7 @@ impl<T: Handler> Router for TreeRouter<T> {
                     }
 
                     for (segment, _next) in &current.static_routes {
-                        result.hypermedia.links.push(Link {
+                        result.hyperlinks.push(Link {
                             method: None,
                             path: vec![LinkSegment {
                                 label: segment.as_slice(),
@@ -278,7 +278,7 @@ impl<T: Handler> Router for TreeRouter<T> {
                     }
 
                     if let Some(ref _next) = current.variable_route {
-                        result.hypermedia.links.push(Link {
+                        result.hyperlinks.push(Link {
                             method: None,
                             path: vec![LinkSegment {
                                 label: MaybeUtf8Slice::new(),
@@ -289,7 +289,7 @@ impl<T: Handler> Router for TreeRouter<T> {
                     }
 
                     if let Some(ref _next) = current.wildcard_route {
-                        result.hypermedia.links.push(Link {
+                        result.hyperlinks.push(Link {
                             method: None,
                             path: vec![LinkSegment {
                                 label: MaybeUtf8Slice::new(),
@@ -464,8 +464,7 @@ mod test {
                 let expected_links = [$(link!($($links)*)),*];
                 for link in &expected_links {
                     let index = endpoint
-                                .hypermedia
-                                .links
+                                .hyperlinks
                                 .iter()
                                 .map(|link| (link.method.as_ref(), &link.path))
                                 .position(|other| match (other, link) {
@@ -474,12 +473,12 @@ mod test {
                                    _ => false
                                 });
                     if let Some(index) = index {
-                        endpoint.hypermedia.links.swap_remove(index);
+                        endpoint.hyperlinks.swap_remove(index);
                     } else {
                         panic!("missing link: {:?}", link);
                     }
                 }
-                assert!(endpoint.hypermedia.links.is_empty());
+                assert!(endpoint.hyperlinks.is_empty());
             }
         );
         

--- a/src/router/tree_router.rs
+++ b/src/router/tree_router.rs
@@ -256,11 +256,12 @@ impl<T: Handler> Router for TreeRouter<T> {
 
                 //Only register hyperlinks on the first pass.
                 if branch == Static {
-                    for (other_method, _) in &current.items {
+                    for (other_method, &(ref item, _)) in &current.items {
                         if other_method != method {
                             result.hypermedia.links.push(Link {
                                 method: Some(other_method.clone()),
-                                path: vec![]
+                                path: vec![],
+                                handler: Some(item)
                             });
                         }
                     }
@@ -271,7 +272,8 @@ impl<T: Handler> Router for TreeRouter<T> {
                             path: vec![LinkSegment {
                                 label: segment.as_slice(),
                                 ty: SegmentType::Static
-                            }]
+                            }],
+                            handler: None
                         });
                     }
 
@@ -281,7 +283,8 @@ impl<T: Handler> Router for TreeRouter<T> {
                             path: vec![LinkSegment {
                                 label: MaybeUtf8Slice::new(),
                                 ty: SegmentType::VariableSegment
-                            }]
+                            }],
+                            handler: None
                         });
                     }
 
@@ -291,7 +294,8 @@ impl<T: Handler> Router for TreeRouter<T> {
                             path: vec![LinkSegment {
                                 label: MaybeUtf8Slice::new(),
                                 ty: SegmentType::VariableSequence
-                            }]
+                            }],
+                            handler: None
                         });
                     }
                 }
@@ -475,7 +479,7 @@ mod test {
                         panic!("missing link: {:?}", link);
                     }
                 }
-                assert_eq!(endpoint.hypermedia.links, vec![]);
+                assert!(endpoint.hypermedia.links.is_empty());
             }
         );
         

--- a/src/server/instance.rs
+++ b/src/server/instance.rs
@@ -24,7 +24,6 @@ use anymap::AnyMap;
 use StatusCode;
 
 use context::{self, Context, Uri, MaybeUtf8Owned, Parameters};
-use context::hypermedia::Hypermedia;
 use filter::{FilterContext, ContextFilter, ContextAction, ResponseFilter};
 use router::{Router, Endpoint};
 use handler::Handler;
@@ -199,7 +198,7 @@ impl<R: Router> HyperHandler for ServerInstance<R> {
                     method: request_method,
                     address: request_addr,
                     uri: uri,
-                    hypermedia: Hypermedia::new(),
+                    hyperlinks: vec![],
                     variables: Parameters::new(),
                     query: query.into(),
                     fragment: fragment,
@@ -217,18 +216,18 @@ impl<R: Router> HyperHandler for ServerInstance<R> {
                             Endpoint {
                                 handler: None,
                                 variables: HashMap::new(),
-                                hypermedia: Hypermedia::new()
+                                hyperlinks: vec![]
                             }
                         });
 
                         let Endpoint {
                             handler,
                             variables,
-                            hypermedia
+                            hyperlinks
                         } = endpoint;
 
                         if let Some(handler) = handler.or(self.fallback_handler.as_ref()) {
-                            context.hypermedia = hypermedia;
+                            context.hyperlinks = hyperlinks;
                             context.variables = variables.into();
                             handler.handle_request(context, response);
                         } else {


### PR DESCRIPTION
This changes some of how hypermedia is delivered to the handlers. It's possible to access the handlers that hyperlinks points at and get a description string from them. Routers are no longer responsible for delivering any other kind of hypermedia, so the `Hypermedia` type has been removed and only hyperlinks are delivered through the `Endpoint`.

This is a breaking change for anything that uses the hyperlinks or the `Hypermedia` structure in any way, including custom routers.