### PR TITLE
Give the user control over the server's keep-alive policy

### DIFF
--- a/src/server/config.rs
+++ b/src/server/config.rs
@@ -2,6 +2,7 @@ use std::net::{SocketAddr, SocketAddrV4, SocketAddrV6, Ipv4Addr};
 use std::str::FromStr;
 use std::any::TypeId;
 use std::mem::swap;
+use std::time::Duration;
 
 use anymap::Map;
 use anymap::any::{Any, UncheckedAnyExt};
@@ -240,4 +241,15 @@ enum GlobalState {
     None,
     One(TypeId, Box<Any + Send + Sync>),
     Many(Map<Any + Send + Sync>),
+}
+
+///Settings for `keep-alive` connections to the server.
+pub struct KeepAlive {
+    ///How long a `keep-alive` connection may idle before it's forced close.
+    pub timeout: Duration,
+
+    ///The number of threads in the thread pool that should be kept free from
+    ///idling threads. Connections will be closed if the number of idle
+    ///threads goes below this.
+    pub free_threads: usize,
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -14,7 +14,7 @@ use handler::Handler;
 use HttpResult;
 
 pub use self::instance::ServerInstance;
-pub use self::config::{Host, Global, Scheme};
+pub use self::config::{Host, Global, Scheme, KeepAlive};
 
 mod instance;
 mod config;
@@ -62,10 +62,10 @@ pub struct Server<R: Router> {
     ///`(num_cores * 5) / 4`.
     pub threads: Option<usize>,
 
-    ///The the minimal number of threads in the thread pool that are required
-    ///to be available for new connections. This can be used to prevent hangs
-    ///during high load. Default is `1`.
-    pub available_threads: usize,
+    ///The server's `keep-alive` policy. Setting this to `Some(...)` will
+    ///allow `keep-alive` connections with a timeout, and keeping it as `None`
+    ///will force connections to close after each request. Default is `None`.
+    pub keep_alive: Option<KeepAlive>,
 
     ///The content of the server header. Default is `"rustful"`.
     pub server: String,
@@ -106,7 +106,7 @@ impl<R: Router> Server<R> {
             host: 80.into(),
             scheme: Scheme::Http,
             threads: None,
-            available_threads: 1,
+            keep_alive: None,
             server: "rustful".to_owned(),
             content_type: Mime(
                 hyper::mime::TopLevel::Text,


### PR DESCRIPTION
The way `keep-alive` connections are handled in Hyper changed recently to close connections by default and allow opt-in `keep-alive` with a timeout. That rendered the `available_threads` option ineffective.

This PR replaces `available_threads` with a new `keep_alive` option that allows opting into `keep-alive`. The `available_threads` is still available as `free_threads` in `KeepAlive` and has the same functionality.

This is breaking for anything that uses the `available_threads` option. Note that the timeout has no effect before Rust 1.4.