### PR TITLE
Remove the extension traits for BodyReader

### DIFF
--- a/examples/post.rs
+++ b/examples/post.rs
@@ -12,7 +12,6 @@ extern crate log;
 extern crate env_logger;
 
 use rustful::{Server, Context, Response};
-use rustful::context::body::ExtQueryBody;
 use rustful::StatusCode::{InternalServerError, BadRequest};
 
 fn say_hello(mut context: Context, mut response: Response) {

--- a/examples/todo.rs
+++ b/examples/todo.rs
@@ -27,7 +27,6 @@ use rustful::header::{
     Host
 };
 use rustful::StatusCode;
-use rustful::context::body::ExtJsonBody;
 
 //Helper for setting a status code and then returning from a function
 macro_rules! or_abort {


### PR DESCRIPTION
Removes the unnecessary extension traits that provided extra parsing methods for `BodyReader`. These has instead been implemented directly.

This will break any project that uses these extension traits.

Closes #76