### PR TITLE
Edit insert_routes! to avoid type ascription conflicts, and some fixes

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ skip_tags: true
 platform: x64
 os: MinGW
 environment:
-  OPENSSL_VERSION: 1_0_2d
+  OPENSSL_VERSION: 1_0_2e
 install:
   - cmd: SET PATH=C:\MINGW\bin\;C:\MINGW\msys\1.0\bin\;%LOCALAPPDATA%\.multirust\toolchains\stable\bin\;%PATH%
   - ps: Start-FileDownload "https://github.com/Diggsey/multirust-rs-binaries/raw/master/i686-pc-windows-gnu/multirust-rs.exe"

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -102,9 +102,9 @@ macro_rules! insert_routes {
 #[macro_export]
 macro_rules! __rustful_insert_internal {
     ($router:ident, [$($steps:expr),*],$(,)*) => {{}};
-    ($router:ident, [$($steps:expr),*], $path:expr => {$($paths:tt)+}, $($next:tt)*) => {
+    ($router:ident, [$($steps:expr),*], $path:tt => {$($paths:tt)+}, $($next:tt)*) => {
         {
-            __rustful_insert_internal!($router, [$($steps,)* $path], $($paths)*);
+            __rustful_insert_internal!($router, [$($steps,)* __rustful_to_expr!($path)], $($paths)*);
             __rustful_insert_internal!($router, [$($steps),*], $($next)*);
         }
     };
@@ -113,7 +113,7 @@ macro_rules! __rustful_insert_internal {
             __rustful_insert_internal!($router, [$($steps,)* __rustful_to_expr!($path)], $($paths)*);
         }
     };
-    ($router:ident, [$($steps:expr),*], $($method:tt)::+: $handler:expr, $($next:tt)*) => {
+    ($router:ident, [$($steps:expr),*], $($method:tt)::+ : $handler:expr, $($next:tt)*) => {
         {
             let method = {
                 #[allow(unused_imports)]
@@ -125,19 +125,19 @@ macro_rules! __rustful_insert_internal {
             __rustful_insert_internal!($router, [$($steps),*], $($next)*);
         }
     };
-    ($router:ident, [$($steps:expr),*], $path:tt => $method:path: $handler:expr, $($next:tt)*) => {
+    ($router:ident, [$($steps:expr),*], $path:tt => $($method:tt)::+ : $handler:expr, $($next:tt)*) => {
         {
             let method = {
                 #[allow(unused_imports)]
                 use $crate::Method::*;
-                $method
+                __rustful_to_path!($($method)::+)
             };
             let path = __rustful_route_expr!($($steps,)* __rustful_to_expr!($path));
             $router.insert(method, &path, $handler);
             __rustful_insert_internal!($router, [$($steps),*], $($next)*);
         }
     };
-    ($router:ident, [$($steps:expr),*], $($method:tt)::+: $handler:expr) => {
+    ($router:ident, [$($steps:expr),*], $($method:tt)::+ : $handler:expr) => {
         {
             let method = {
                 #[allow(unused_imports)]
@@ -148,12 +148,12 @@ macro_rules! __rustful_insert_internal {
             $router.insert(method, &path, $handler);
         }
     };
-    ($router:ident, [$($steps:expr),*], $path:tt => $method:path: $handler:expr) => {
+    ($router:ident, [$($steps:expr),*], $path:tt => $($method:tt)::+ : $handler:expr) => {
         {
             let method = {
                 #[allow(unused_imports)]
                 use $crate::Method::*;
-                $method
+                __rustful_to_path!($($method)::+)
             };
             let path = __rustful_route_expr!($($steps,)* __rustful_to_expr!($path));
             $router.insert(method, &path, $handler);

--- a/src/router/tree_router.rs
+++ b/src/router/tree_router.rs
@@ -568,7 +568,7 @@ mod test {
         SelfLink(Method),
         ForwardLink(Vec<LinkSegment<'a>>)
     }
-    pub use self::LinkType::{SelfLink, ForwardLink};
+    use self::LinkType::{SelfLink, ForwardLink};
 
     #[test]
     fn one_static_route() {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -9,7 +9,6 @@ pub use hyper::server::Listening;
 
 use filter::{ContextFilter, ResponseFilter};
 use router::Router;
-use handler::Handler;
 
 use HttpResult;
 


### PR DESCRIPTION
This changes the syntax of `insert_routes!` to always take paths and methods as token trees to avoid conflicts with the upcoming type ascription syntax. There are also some bonus changes to avoid some warnings and to make the Windows tests work again.