### PR TITLE
Router composition

### DIFF
--- a/src/context/hypermedia.rs
+++ b/src/context/hypermedia.rs
@@ -6,6 +6,7 @@ use Handler;
 use context::MaybeUtf8Slice;
 
 ///A hyperlink.
+#[derive(Clone)]
 pub struct Link<'a> {
     ///The HTTP method for which an endpoint is available. It can be left
     ///unspecified if the method doesn't matter.
@@ -23,7 +24,7 @@ impl<'a> fmt::Debug for Link<'a> {
 }
 
 ///A segment of a hyperlink path.
-#[derive(PartialEq, Eq, Debug)]
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub struct LinkSegment<'a> {
     ///The expected static segment or the name of a variable segment. Variable
     ///segments are allowed to have an empty string as label if it's unknown or
@@ -34,7 +35,7 @@ pub struct LinkSegment<'a> {
 }
 
 ///The type of a hyperlink segment.
-#[derive(PartialEq, Eq, Debug)]
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub enum SegmentType {
     ///A static part of a path.
     Static,

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -89,7 +89,7 @@
 macro_rules! insert_routes {
     ($router:expr => {$($paths:tt)+}) => {
         {
-            use $crate::Router;
+            use $crate::router::Router;
             let mut router = $router;
             __rustful_insert_internal!(router, [], $($paths)+);
             router
@@ -121,7 +121,7 @@ macro_rules! __rustful_insert_internal {
                 __rustful_to_path!($($method)::+)
             };
             let path = __rustful_route_expr!($($steps),*);
-            $router.insert(method, &path, $handler);
+            $router.insert(method, path, $handler);
             __rustful_insert_internal!($router, [$($steps),*], $($next)*);
         }
     };
@@ -133,7 +133,7 @@ macro_rules! __rustful_insert_internal {
                 __rustful_to_path!($($method)::+)
             };
             let path = __rustful_route_expr!($($steps,)* __rustful_to_expr!($path));
-            $router.insert(method, &path, $handler);
+            $router.insert(method, path, $handler);
             __rustful_insert_internal!($router, [$($steps),*], $($next)*);
         }
     };
@@ -145,7 +145,7 @@ macro_rules! __rustful_insert_internal {
                 __rustful_to_path!($($method)::+)
             };
             let path = __rustful_route_expr!($($steps),*);
-            $router.insert(method, &path, $handler);
+            $router.insert(method, path, $handler);
         }
     };
     ($router:ident, [$($steps:expr),*], $path:tt => $($method:tt)::+ : $handler:expr) => {
@@ -156,7 +156,7 @@ macro_rules! __rustful_insert_internal {
                 __rustful_to_path!($($method)::+)
             };
             let path = __rustful_route_expr!($($steps,)* __rustful_to_expr!($path));
-            $router.insert(method, &path, $handler);
+            $router.insert(method, path, $handler);
         }
     };
 }

--- a/src/router/method_router.rs
+++ b/src/router/method_router.rs
@@ -1,49 +1,64 @@
-use std::collections::HashMap;
+use std::collections::hash_map::{HashMap, Entry};
 
 use router::{Router, Endpoint, InsertState, RouteState};
-use context::MaybeUtf8Owned;
 use context::hypermedia::Link;
-use {Method, Handler};
+use Method;
 
 ///A router which selects a handler from an HTTP method.
+#[derive(Clone)]
 pub struct MethodRouter<T> {
-    items: HashMap<Method, (T, Vec<MaybeUtf8Owned>)>,
+    items: HashMap<Method, T>,
 }
 
-impl<T: Handler> Router for MethodRouter<T> {
-    type Handler = T;
+impl<T: Router> Router for MethodRouter<T> {
+    type Handler = T::Handler;
 
-    fn find<'a>(&'a self, method: &Method, route: &mut RouteState) -> Endpoint<'a, T> {
-        if let Some(&(ref h, ref variables)) = self.items.get(method) {
-            Endpoint {
-                handler: Some(h),
-                variables: route.variables(variables),
-                hyperlinks: vec![],
-            }
+    fn find<'a>(&'a self, method: &Method, route: &mut RouteState) -> Endpoint<'a, Self::Handler> {
+        if let Some(item) = self.items.get(method) {
+            item.find(method, route)
         } else {
             Endpoint::from(None)
         }
     }
 
     fn hyperlinks<'a>(&'a self, base: Link<'a>) -> Vec<Link<'a>> {
-        self.items.iter().map(|(method, &(ref item, _))| {
+        self.items.iter().flat_map(|(method, item)| {
             let mut link = base.clone();
             link.method = Some(method.clone());
-            link.handler = Some(item);
-            link
+            item.hyperlinks(link)
         }).collect()
     }
 
+    fn build<'a, R: Into<InsertState<'a, I>>, I: Iterator<Item = &'a [u8]>>(method: Method, route: R, item: Self::Handler) -> MethodRouter<T> {
+        let mut router = MethodRouter::default();
+        router.insert(method, route, item);
+        router
+    }
+
     fn insert<'a, R: Into<InsertState<'a, I>>, I: Iterator<Item = &'a [u8]>>(&mut self, method: Method, route: R, item: Self::Handler) {
-        self.items.insert(method, (item, route.into().variables()));
+        self.items.insert(method.clone(), T::build(method, route, item));
     }
 
     fn insert_router<'a, R: Into<InsertState<'a, I>>, I: Clone + Iterator<Item = &'a [u8]>>(&mut self, route: R, router: MethodRouter<T>) {
-        let prefix = route.into().variables();
-        for (method, (item, variables)) in router.items {
-            let mut new_vars = prefix.clone();
-            new_vars.extend(variables);
-            self.items.insert(method, (item, new_vars));
+        let route = route.into();
+        for (method, mut item) in router.items {
+            match self.items.entry(method) {
+                Entry::Occupied(mut e) => {
+                    e.get_mut().insert_router(route.clone(), item);
+                },
+                Entry::Vacant(e) => {
+                    item.prefix(route.clone());
+                    e.insert(item);
+                }
+            }
+        }
+    }
+
+    fn prefix<'a, R: Into<InsertState<'a, I>>, I: Clone + Iterator<Item = &'a [u8]>>(&mut self, route: R) {
+        let route = route.into();
+
+        for (_, item) in &mut self.items {
+            item.prefix(route.clone());
         }
     }
 }

--- a/src/router/method_router.rs
+++ b/src/router/method_router.rs
@@ -4,7 +4,11 @@ use router::{Router, Endpoint, InsertState, RouteState};
 use context::hypermedia::Link;
 use Method;
 
-///A router which selects a handler from an HTTP method.
+///A router that selects an item from an HTTP method.
+///
+///It's a simple mapping between `Method` and a router `T`, while the
+///requested path is ignored. It's therefore a good idea to pair a
+///`MethodRouter` with an exhaustive path router of some sort.
 #[derive(Clone)]
 pub struct MethodRouter<T> {
     items: HashMap<Method, T>,

--- a/src/router/method_router.rs
+++ b/src/router/method_router.rs
@@ -1,0 +1,57 @@
+use std::collections::HashMap;
+
+use router::{Router, Endpoint, InsertState, RouteState};
+use context::MaybeUtf8Owned;
+use context::hypermedia::Link;
+use {Method, Handler};
+
+///A router which selects a handler from an HTTP method.
+pub struct MethodRouter<T> {
+    items: HashMap<Method, (T, Vec<MaybeUtf8Owned>)>,
+}
+
+impl<T: Handler> Router for MethodRouter<T> {
+    type Handler = T;
+
+    fn find<'a>(&'a self, method: &Method, route: &mut RouteState) -> Endpoint<'a, T> {
+        if let Some(&(ref h, ref variables)) = self.items.get(method) {
+            Endpoint {
+                handler: Some(h),
+                variables: route.variables(variables),
+                hyperlinks: vec![],
+            }
+        } else {
+            Endpoint::from(None)
+        }
+    }
+
+    fn hyperlinks<'a>(&'a self, base: Link<'a>) -> Vec<Link<'a>> {
+        self.items.iter().map(|(method, &(ref item, _))| {
+            let mut link = base.clone();
+            link.method = Some(method.clone());
+            link.handler = Some(item);
+            link
+        }).collect()
+    }
+
+    fn insert<'a, R: Into<InsertState<'a, I>>, I: Iterator<Item = &'a [u8]>>(&mut self, method: Method, route: R, item: Self::Handler) {
+        self.items.insert(method, (item, route.into().variables()));
+    }
+
+    fn insert_router<'a, R: Into<InsertState<'a, I>>, I: Clone + Iterator<Item = &'a [u8]>>(&mut self, route: R, router: MethodRouter<T>) {
+        let prefix = route.into().variables();
+        for (method, (item, variables)) in router.items {
+            let mut new_vars = prefix.clone();
+            new_vars.extend(variables);
+            self.items.insert(method, (item, new_vars));
+        }
+    }
+}
+
+impl<T> Default for MethodRouter<T> {
+    fn default() -> MethodRouter<T> {
+        MethodRouter {
+            items: HashMap::new(),
+        }
+    }
+}

--- a/src/router/variables.rs
+++ b/src/router/variables.rs
@@ -3,10 +3,13 @@ use context::MaybeUtf8Owned;
 use context::hypermedia::Link;
 use {Method, Handler};
 
-///An endpoint which assigns names to route variables.
+///A router endpoint that assigns names to route variables.
 ///
 ///It's technically a single-item router, with the purpose of pairing route
-///variable names with input values.
+///variable names with input values, but it can't contain other routers, since
+///it has be at the end of a router chain to know what variables to use. It
+///won't do any other routing work, so make sure to pair it with, at least, a
+///path based router.
 #[derive(Clone)]
 pub struct Variables<H: Handler> {
     handler: H,

--- a/src/router/variables.rs
+++ b/src/router/variables.rs
@@ -1,0 +1,63 @@
+use router::{Router, Endpoint, InsertState, RouteState};
+use context::MaybeUtf8Owned;
+use context::hypermedia::Link;
+use {Method, Handler};
+
+///An endpoint which assigns names to route variables.
+///
+///It's technically a single-item router, with the purpose of pairing route
+///variable names with input values.
+#[derive(Clone)]
+pub struct Variables<H: Handler> {
+    handler: H,
+    variables: Vec<MaybeUtf8Owned>,
+}
+
+impl<H: Handler> Router for Variables<H> {
+    type Handler = H;
+
+    fn find<'a>(&'a self, _method: &Method, route: &mut RouteState) -> Endpoint<'a, H> {
+        Endpoint {
+            handler: Some(&self.handler),
+            variables: route.variables(&self.variables),
+            hyperlinks: vec![],
+        }
+    }
+
+    fn hyperlinks<'a>(&'a self, mut base: Link<'a>) -> Vec<Link<'a>> {
+        base.handler = Some(&self.handler);
+        vec![base]
+    }
+
+    fn build<'a, R: Into<InsertState<'a, I>>, I: Iterator<Item = &'a [u8]>>(_method: Method, route: R, item: Self::Handler) -> Variables<H> {
+        Variables {
+            handler: item,
+            variables: route.into().variables(),
+        }
+    }
+
+    fn insert<'a, R: Into<InsertState<'a, I>>, I: Iterator<Item = &'a [u8]>>(&mut self, _method: Method, route: R, item: Self::Handler) {
+        self.handler = item;
+        self.variables = route.into().variables();
+    }
+
+    fn insert_router<'a, R: Into<InsertState<'a, I>>, I: Clone + Iterator<Item = &'a [u8]>>(&mut self, route: R, mut router: Variables<H>) {
+        router.prefix(route);
+        *self = router;
+    }
+
+    fn prefix<'a, R: Into<InsertState<'a, I>>, I: Clone + Iterator<Item = &'a [u8]>>(&mut self, route: R) {
+        let mut new_vars = route.into().variables();
+        new_vars.extend(self.variables.drain(..));
+        self.variables = new_vars;
+    }
+}
+
+impl<H: Handler + Default> Default for Variables<H> {
+    fn default() -> Variables<H> {
+        Variables {
+            handler: H::default(),
+            variables: vec![],
+        }
+    }
+}

--- a/src/server/instance.rs
+++ b/src/server/instance.rs
@@ -226,7 +226,7 @@ impl<R: Router> HyperHandler for ServerInstance<R> {
                                 variables: HashMap::new(),
                                 hyperlinks: vec![]
                             }
-                        }, |path| self.handlers.find(&context.method, &path));
+                        }, |path| self.handlers.find(&context.method, &mut (&path[..]).into()));
 
                         let Endpoint {
                             handler,


### PR DESCRIPTION
This makes the library support composable routers and closes #86. The `Router` trait is changed to make it easier to have routers within routers, by taking part of the routing state as an argument to `find`. `TreeRouter` is changed to support inner routers, and the method routing and variable parts are extracted into `MethodRuter` and `Variables`. These being together is still favored by the `TreeRouter::new()` and  `TreeRouter::from_iter(...)` methods, by creating a `TreeRouter<MethodRouter<Variables<H>>>` instead of just a `TreeRouter<T>`.

This is a breaking change, since it changes the `Router` trait and the composition of `TreeRouter`. It will, however, not be noticeable by everyone, since the basic behavior is the same.