### PR TITLE
Fix some Clippy warnings

### DIFF
--- a/src/context/maybe_utf8.rs
+++ b/src/context/maybe_utf8.rs
@@ -62,7 +62,7 @@ impl<S, V> MaybeUtf8<S, V> {
     ///let string = MaybeUtf8Owned::from("abc");
     ///assert_eq!("abc", string.as_utf8_lossy());
     ///```
-    pub fn as_utf8_lossy<'a>(&'a self) -> Cow<'a, str> where S: AsRef<str>, V: AsRef<[u8]> {
+    pub fn as_utf8_lossy(&self) -> Cow<str> where S: AsRef<str>, V: AsRef<[u8]> {
         match *self {
             MaybeUtf8::Utf8(ref s) => s.as_ref().into(),
             MaybeUtf8::NotUtf8(ref v) => String::from_utf8_lossy(v.as_ref())

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -197,7 +197,7 @@ impl Uri {
 
     ///Borrow the URI as a UTF-8 path, if valid, or convert it to a valid
     ///UTF-8 string.
-    pub fn as_utf8_path_lossy<'a>(&'a self) -> Option<Cow<'a, str>> {
+    pub fn as_utf8_path_lossy(&self) -> Option<Cow<str>> {
         match *self {
             Uri::Path(ref path) => Some(path.as_utf8_lossy()),
             Uri::Asterisk => None

--- a/src/response.rs
+++ b/src/response.rs
@@ -519,7 +519,7 @@ impl<'a, 'b> Response<'a, 'b> {
         let mime = path
             .extension()
             .and_then(|ext| to_mime(&ext.to_string_lossy()))
-            .unwrap_or(Mime(TopLevel::Application, SubLevel::Ext("octet-stream".into()), vec![]));
+            .unwrap_or_else(|| Mime(TopLevel::Application, SubLevel::Ext("octet-stream".into()), vec![]));
 
         let mut file = match File::open(path) {
             Ok(file) => file,

--- a/src/response.rs
+++ b/src/response.rs
@@ -144,8 +144,7 @@ impl<'a, 'b> FileError<'a, 'b> {
 impl<'a, 'b> Into<io::Error> for FileError<'a, 'b> {
     fn into(self) -> io::Error {
         match self {
-            FileError::Open(e, _) => e,
-            FileError::Send(e) => e
+            FileError::Open(e, _) | FileError::Send(e) => e
         }
     }
 }
@@ -171,15 +170,13 @@ impl<'a, 'b> std::fmt::Display for FileError<'a, 'b> {
 impl<'a, 'b> error::Error for FileError<'a, 'b> {
     fn description(&self) -> &str {
         match *self {
-            FileError::Open(ref e, _) => e.description(),
-            FileError::Send(ref e) => e.description()
+            FileError::Open(ref e, _) | FileError::Send(ref e) => e.description()
         }
     }
 
     fn cause(&self) -> Option<&std::error::Error> {
         match *self {
-            FileError::Open(ref e, _) => Some(e),
-            FileError::Send(ref e) => Some(e)
+            FileError::Open(ref e, _) | FileError::Send(ref e) => Some(e)
         }
     }
 }
@@ -900,8 +897,7 @@ fn filter_headers<'a>(
 
     for filter in filters {
         header_result = match header_result {
-            (_, Action::SilentAbort) => break,
-            (_, Action::Abort(_)) => break,
+            (_, Action::SilentAbort) | (_, Action::Abort(_)) => break,
             (status, r) => {
                 write_queue.push(r);
 
@@ -917,7 +913,7 @@ fn filter_headers<'a>(
                     (status, Action::Abort(e)) => (status, Action::Abort(e)),
                     (status, result) => {
                         let mut error = None;
-                        
+
                         write_queue = write_queue.into_iter().filter_map(|action| match action {
                             Action::Next(content) => {
                                 let filter_context = FilterContext {

--- a/src/router/tree_router.rs
+++ b/src/router/tree_router.rs
@@ -147,7 +147,7 @@ impl<T: Router + Default> Router for TreeRouter<T> {
                         }
                     }
 
-                    for (segment, _next) in &current.static_routes {
+                    for segment in current.static_routes.keys() {
                         result.hyperlinks.push(Link {
                             method: None,
                             path: vec![LinkSegment {
@@ -224,7 +224,7 @@ impl<T: Router + Default> Router for TreeRouter<T> {
     fn hyperlinks<'a>(&'a self, base: Link<'a>) -> Vec<Link<'a>> {
         let mut links = self.item.hyperlinks(base.clone());
 
-        for (segment, _next) in &self.static_routes {
+        for segment in self.static_routes.keys() {
             let mut link = base.clone();
             link.path.push(LinkSegment {
                 label: segment.as_slice(),

--- a/src/server/config.rs
+++ b/src/server/config.rs
@@ -48,9 +48,9 @@ impl Host {
     ///Change the port of the host address.
     pub fn port(&mut self, port: u16) {
         self.0 = match self.0 {
-            SocketAddr::V4(addr) => SocketAddr::V4(SocketAddrV4::new(addr.ip().clone(), port)),
+            SocketAddr::V4(addr) => SocketAddr::V4(SocketAddrV4::new(*addr.ip(), port)),
             SocketAddr::V6(addr) => {
-                SocketAddr::V6(SocketAddrV6::new(addr.ip().clone(), port, addr.flowinfo(), addr.scope_id()))
+                SocketAddr::V6(SocketAddrV6::new(*addr.ip(), port, addr.flowinfo(), addr.scope_id()))
             }
         };
     }

--- a/src/server/instance.rs
+++ b/src/server/instance.rs
@@ -266,7 +266,7 @@ fn parse_path(path: &str) -> ParsedUri {
 
             let mut path = percent_decode(path[..index].as_bytes());
             if path.is_empty() {
-                path.push('/' as u8);
+                path.push(b'/');
             }
 
             ParsedUri {
@@ -281,7 +281,7 @@ fn parse_path(path: &str) -> ParsedUri {
 
             let mut path = percent_decode(path.as_bytes());
             if path.is_empty() {
-                path.push('/' as u8);
+                path.push(b'/');
             }
 
             ParsedUri {
@@ -304,11 +304,11 @@ fn parse_fragment(path: &str) -> (&str, Option<&str>) {
 fn parse_url(url: Url) -> ParsedUri {
     let mut path = Vec::new();
     for component in url.path().unwrap_or(&[]) {
-        path.push('/' as u8);
+        path.push(b'/');
         percent_decode_to(component.as_bytes(), &mut path);
     }
     if path.is_empty() {
-        path.push('/' as u8);
+        path.push(b'/');
     }
 
     let query = url.query_pairs()

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -5,11 +5,11 @@ use context::Parameters;
 pub fn parse_parameters(source: &[u8]) -> Parameters {
     let mut parameters = Parameters::new();
     let source: Vec<u8> = source.iter()
-                                .map(|&e| if e == '+' as u8 { ' ' as u8 } else { e })
+                                .map(|&e| if e == b'+' { b' ' } else { e })
                                 .collect();
 
-    for parameter in source.split(|&e| e == '&' as u8) {
-        let mut parts = parameter.split(|&e| e == '=' as u8);
+    for parameter in source.split(|&e| e == b'&') {
+        let mut parts = parameter.split(|&e| e == b'=');
 
         match (parts.next(), parts.next()) {
             (Some(name), Some(value)) => {


### PR DESCRIPTION
There are 5 warnings left:

- one `needless_lifetimes` which is a false positive (reported there: https://github.com/Manishearth/rust-clippy/issues/740#issuecomment-205826823);
- 3 `type_complexity` warnings that I did not fix because they seem legit;
- one `wrong_self_convention` which seems semi-legit too, although it’s a little surprising to have an `is_empty` function require a `&mut self`.

Here they are, FYI:
```rust
src/router/tree_router.rs:80:5: 110:6 warning: explicit lifetimes given in parameter types where they could be elided, #[warn(needless_lifetimes)] on by default
src/router/tree_router.rs: 80     fn merge_router<'a, I: Iterator<Item = &'a [u8]> + Clone>(&mut self, state: InsertState<'a, I>, router: TreeRouter<T>) {
src/router/tree_router.rs: 81         self.item.insert_router(state.clone(), router.item);
src/router/tree_router.rs: 82 
src/router/tree_router.rs: 83         for (key, router) in router.static_routes {
src/router/tree_router.rs: 84             let next = match self.static_routes.entry(key.clone()) {
src/router/tree_router.rs: 85                 Occupied(entry) => entry.into_mut(),
                              ...
src/router/tree_router.rs:80:5: 110:6 help: for further information visit https://github.com/Manishearth/rust-clippy/wiki#needless_lifetimes
src/router/mod.rs:357:21: 357:71 warning: very complex type used. Consider factoring parts into `type` definitions, #[warn(type_complexity)] on by default
src/router/mod.rs:357     type Segments = RouteIter<Split<'a, u8, &'static fn(&u8) -> bool>>;
                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/router/mod.rs:357:21: 357:71 help: for further information visit https://github.com/Manishearth/rust-clippy/wiki#type_complexity
src/router/mod.rs:365:21: 365:71 warning: very complex type used. Consider factoring parts into `type` definitions, #[warn(type_complexity)] on by default
src/router/mod.rs:365     type Segments = RouteIter<Split<'a, u8, &'static fn(&u8) -> bool>>;
                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/router/mod.rs:365:21: 365:71 help: for further information visit https://github.com/Manishearth/rust-clippy/wiki#type_complexity
src/router/mod.rs:393:21: 393:170 warning: very complex type used. Consider factoring parts into `type` definitions, #[warn(type_complexity)] on by default
src/router/mod.rs:393     type Segments = FlatMap<<&'a I as IntoIterator>::IntoIter, <<T as Deref>::Target as Route<'a>>::Segments, fn(&'a T) -> <<T as Deref>::Target as Route<'a>>::Segments>;
                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/router/mod.rs:393:21: 393:170 help: for further information visit https://github.com/Manishearth/rust-clippy/wiki#type_complexity
src/router/mod.rs:449:21: 449:34 warning: methods called `is_*` usually take self by reference or no self; consider choosing a less ambiguous name, #[warn(wrong_self_convention)] on by default
src/router/mod.rs:449     pub fn is_empty(&mut self) -> bool {
                                          ^~~~~~~~~~~~~
src/router/mod.rs:449:21: 449:34 help: for further information visit https://github.com/Manishearth/rust-clippy/wiki#wrong_self_convention
```