### PR TITLE
Change the default content type to text/html

### DIFF
--- a/examples/handler_storage.rs
+++ b/examples/handler_storage.rs
@@ -56,7 +56,6 @@ fn main() {
     let server_result = Server {
         host: 8080.into(),
         handlers: router,
-        content_type: content_type!(Text / Html; Charset = Utf8),
         ..Server::default()
     }.run();
 

--- a/examples/post.rs
+++ b/examples/post.rs
@@ -60,7 +60,6 @@ fn main() {
     let server_result = Server {
         host: 8080.into(),
         global: Box::new(files).into(),
-        content_type: content_type!(Text / Html; Charset = Utf8),
         ..Server::new(say_hello)
     }.run();
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -109,7 +109,7 @@ impl<R: Router> Server<R> {
             server: "rustful".to_owned(),
             content_type: Mime(
                 hyper::mime::TopLevel::Text,
-                hyper::mime::SubLevel::Plain,
+                hyper::mime::SubLevel::Html,
                 vec![(hyper::mime::Attr::Charset, hyper::mime::Value::Utf8)]
             ),
             global: Global::default(),


### PR DESCRIPTION
This changes the default content type for responses to text/html.

It's a breaking change, since it will make it necessary to explicitly say that you want text/plain.

Closes #107.