### PR TITLE
Update dependencies and remove built in OpenSSL support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ rust:
   - nightly
 os:
   - linux
-#  - osx
+  - osx
 branches:
   only:
     - master

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,8 @@ name = "rustful"
 path = "src/lib.rs"
 
 [features]
-default = ["rustc_json_body", "ssl", "multipart"]
+default = ["rustc_json_body", "multipart"]
 rustc_json_body = ["rustc-serialize"]
-ssl = ["hyper/ssl"]
 
 #internal
 benchmark = []
@@ -33,8 +32,7 @@ num_cpus = "0.2"
 log = "0.3"
 
 [dependencies.hyper]
-version = "0.9"
-default-features = false
+version = "0.10"
 
 [dependencies.multipart]
 #feature

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ version = "0.10"
 
 [dependencies.multipart]
 #feature
-version = "0.7"
+version = "0.12"
 default-features = false
 features = ["server"]
 optional = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ time = "0.1"
 url = "1"
 anymap = "0.12"
 phf = "0.7"
-num_cpus = "0.2"
+num_cpus = "1"
 log = "0.3"
 
 [dependencies.hyper]
@@ -47,7 +47,7 @@ optional = true
 
 [dev-dependencies]
 unicase = "1.0"
-env_logger = "0.3"
+env_logger = "0.4"
 
 [build-dependencies]
 phf_codegen = "0.7"

--- a/README.md
+++ b/README.md
@@ -40,11 +40,22 @@ Some parts of Rustful can be toggled using Cargo features:
  * `multipart` - Enable parsing of `multipart/form-data` requests. Enabled by default.
 
 ### Using SSL
-Note that the `ssl` feature requires OpenSSL to be installed in one way or
-another. See https://github.com/sfackler/rust-openssl#building for more
-instructions.
+
+Rustful support SSL (HTTPS), but does not provide the actual SSL connection.
+It's however compatible with anything that's made for the same Hyper version,
+so all you have to do is find the one that suits your needs and plug it into
+the server:
+
+```rust
+let server_result = Server {
+    handlers: router,
+    host: 8080.into(),
+    ..Server::default()
+}.run_https(my_ssl_server);
+```
 
 ## Write Your Server
+
 Here is a simple example of what a simple project could look like. Visit
 `http://localhost:8080` or `http://localhost:8080/Olivia` (if your name is
 Olivia) to try it.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,14 +5,8 @@ branches:
 skip_tags: true
 platform: x64
 os: MinGW
-environment:
-  OPENSSL_VERSION: 1_0_2k
 install:
   - cmd: SET PATH=C:\MINGW\bin\;C:\MINGW\msys\1.0\bin\;C:\Users\appveyor\.multirust\toolchains\stable\bin\;%PATH%
-  - ps: Start-FileDownload "http://slproweb.com/download/Win32OpenSSL-$Env:OPENSSL_VERSION.exe"
-  - cmd: Win32OpenSSL-%OPENSSL_VERSION%.exe /silent /verysilent /sp- /suppressmsgboxes
-  - cmd: SET OPENSSL_LIB_DIR=C:\OpenSSL-Win32
-  - cmd: SET OPENSSL_INCLUDE_DIR=C:\OpenSSL-Win32\include
   - ps: Start-FileDownload "https://github.com/rust-lang-nursery/multirust-rs-binaries/raw/master/i686-pc-windows-gnu/multirust-setup.exe"
   - multirust-setup -y -v
   - rustc --version

--- a/src/context/body.rs
+++ b/src/context/body.rs
@@ -114,7 +114,7 @@ impl<'a, 'b> BodyReader<'a, 'b> {
     ///        multipart.foreach_entry(|entry| match entry.data {
     ///            MultipartData::Text(text) => {
     ///                //Found data from a text field
-    ///                writeln!(&mut result, "{}: '{}'", entry.name, text);
+    ///                writeln!(&mut result, "{}: '{}'", entry.name, text.text);
     ///            },
     ///            MultipartData::File(file) => {
     ///                //Found an uploaded file

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,3 +113,4 @@ pub mod context;
 pub mod response;
 pub mod filter;
 pub mod file;
+pub mod net;

--- a/src/net.rs
+++ b/src/net.rs
@@ -1,0 +1,3 @@
+//! Network related types and traits, reexported from Hyper.
+
+pub use hyper::net::{SslServer, HttpStream, NetworkStream};

--- a/src/server/config.rs
+++ b/src/server/config.rs
@@ -7,22 +7,6 @@ use std::time::Duration;
 use anymap::Map;
 use anymap::any::{Any, UncheckedAnyExt};
 
-///HTTP or HTTPS.
-pub enum Scheme {
-    ///Standard HTTP.
-    Http,
-
-    ///HTTP with SSL encryption.
-    #[cfg(feature = "ssl")]
-    Https {
-        ///Path to SSL certificate.
-        cert: ::std::path::PathBuf,
-
-        ///Path to key file.
-        key: ::std::path::PathBuf
-    }
-}
-
 ///A host address and a port.
 ///
 ///Can be conveniently converted from an existing address-port pair or just a port:


### PR DESCRIPTION
Hyper removed the build in OpenSSL support, in favor of external crates, so we are doing the same. This is therefore an especially breaking change. The good part is that this removes a whole world of testing problems.

Closes #124, closes #108.